### PR TITLE
add support for leading `../` in patterns

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -73,6 +73,16 @@ test('handle absolute patterns to some extent', async () => {
   assert.deepEqual(files.sort(), ['a/a.ts']);
 });
 
+test('leading ../', async () => {
+  const files = await glob({ patterns: ['../b/*.ts'], cwd: path.join(cwd, 'a') });
+  assert.deepEqual(files.sort(), ['../b/a.ts', '../b/b.ts']);
+});
+
+test('leading ../ with absolute on', async () => {
+  const files = await glob({ patterns: ['../b/*.ts'], absolute: true, cwd: path.join(cwd, 'a') });
+  assert.deepEqual(files.sort(), [`${cwd.replaceAll('\\', '/')}/b/a.ts`, `${cwd.replaceAll('\\', '/')}/b/b.ts`]);
+});
+
 test('bracket expanding', async () => {
   const files = await glob({ patterns: ['a/{a,b}.ts'], cwd });
   assert.deepEqual(files.sort(), ['a/a.ts', 'a/b.ts']);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -140,9 +140,11 @@ test('using extglob patterns', async () => {
 });
 
 test('pattern normalization', async () => {
-  const files1 = await glob({ patterns: ['a/'], cwd });
-  const files2 = await glob({ patterns: ['a'], cwd });
+  const files1 = await glob({ patterns: ['a'], cwd });
+  const files2 = await glob({ patterns: ['a/'], cwd });
+  const files3 = await glob({ patterns: ['./a'], cwd });
   assert.deepEqual(files1, files2);
+  assert.deepEqual(files1, files3);
 });
 
 test('negative patterns in options', async () => {


### PR DESCRIPTION
### Current Status

unsure if it's needed, will only merge if i see actual usecases in the wild that break without this.

if you need this, please let me know!

---

kinda hacky, but i can't think of anything else. has a notable performance hit if patterns start with `../` unless ignore options are better configured by the user

imagine you do the following:

```js
glob(['../b/*.ts', '*.ts'], {
  cwd: 'users/me/projects/a'
});

// ['../b/a.ts', 'a.ts']
```

where the projects directory contains `a/a.ts` and `b/a.ts`, in addition to a `node_modules` folder bigger than god knows what.

in this case, tinyglobby infers a common root of `users/me/projects`, and it will start crawling every file under that root. this includes everything inside `node_modules`.

as such, it does some extra crawling that can make the whole thing potentially very slow. one solution for this would be for the user to manually ignore everything they don't want:

```js
glob(['../b/*.ts', '*.ts'], {
  cwd: 'users/me/projects/a',
  ignore: ['../node_modules/**']
});

// ['../b/a.ts', 'a.ts']
```

this makes it fast again. thoughts?