### PR TITLE
add `escapePath` utility function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -230,9 +230,10 @@ export function globSync(patternsOrOptions: string | string[] | GlobOptions, opt
  * Posix: ()*?[]{|}, !+@ before (, ! at the beginning, \\ before non-special characters.
  * Windows: (){}[], !+@ before (, ! at the beginning.
  */
-const UNESCAPED_GLOB_SYMBOLS_RE = os.platform() === 'win32'
-  ? /(?<escape>\\?)(?<symbols>[()[\]{}]|^!|[!+@](?=\())/g
-  : /(?<escape>\\?)(?<symbols>[()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
+const UNESCAPED_GLOB_SYMBOLS_RE =
+  os.platform() === 'win32'
+    ? /(?<escape>\\?)(?<symbols>[()[\]{}]|^!|[!+@](?=\())/g
+    : /(?<escape>\\?)(?<symbols>[()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
 
 export function escapePath(pattern: string): string {
   const source = ([] as unknown[]).concat(pattern);

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,10 +236,8 @@ const UNESCAPED_GLOB_SYMBOLS_RE =
     : /(?<escape>\\?)(?<symbols>[()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
 
 export function escapePath(pattern: string): string {
-  const source = ([] as unknown[]).concat(pattern);
-  const isValidSource = source.every(item => typeof item === 'string' && item !== '');
-  if (!isValidSource) {
-    throw new TypeError('Patterns must be a string (non empty) or an array of strings');
+  if (typeof pattern !== 'string' || pattern === '') {
+    throw new TypeError('Patterns must be a string (non empty) or an array of strings')
   }
   return pattern.replaceAll(UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,14 +242,7 @@ function assertPatternsInput(input: unknown) {
   }
 }
 
-function escapeWindowsPath(pattern: string): string {
+export function escapePath(pattern: string): string {
   assertPatternsInput(pattern);
-  return pattern.replaceAll(WINDOWS_UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
+  return pattern.replaceAll(os.platform() === 'win32' ? WINDOWS_UNESCAPED_GLOB_SYMBOLS_RE : POSIX_UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
 }
-
-function escapePosixPath(pattern: string): string {
-  assertPatternsInput(pattern);
-  return pattern.replaceAll(POSIX_UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
-}
-
-export const escapePath: (pattern: string) => string = os.platform() === 'win32' ? escapeWindowsPath : escapePosixPath;

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,11 +223,7 @@ export function globSync(patternsOrOptions: string | string[] | GlobOptions, opt
   return crawl(opts, cwd, true);
 }
 
-// code below copied from fast-glob under MIT license
-
-const escaper = os.platform() === 'win32' ? escapeWindowsPath : escapePosixPath;
-
-export const escapePath = withPatternsInputAssert(escaper);
+// code below derived from fast-glob under MIT license
 
 /**
  * All non-escaped special characters.
@@ -236,14 +232,6 @@ export const escapePath = withPatternsInputAssert(escaper);
  */
 const POSIX_UNESCAPED_GLOB_SYMBOLS_RE = /(?<escape>\\?)(?<symbols>[()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
 const WINDOWS_UNESCAPED_GLOB_SYMBOLS_RE = /(?<escape>\\?)(?<symbols>[()[\]{}]|^!|[!+@](?=\())/g;
-
-function escapeWindowsPath(pattern: string): string {
-  return pattern.replaceAll(WINDOWS_UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
-}
-
-function escapePosixPath(pattern: string): string {
-  return pattern.replaceAll(POSIX_UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
-}
 
 function assertPatternsInput(input: unknown) {
   const source = ([] as unknown[]).concat(input);
@@ -254,10 +242,14 @@ function assertPatternsInput(input: unknown) {
   }
 }
 
-function withPatternsInputAssert(method: (source: string) => string) {
-  return (source: string): string => {
-    assertPatternsInput(source);
-
-    return method(source);
-  };
+function escapeWindowsPath(pattern: string): string {
+  assertPatternsInput(pattern);
+  return pattern.replaceAll(WINDOWS_UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
 }
+
+function escapePosixPath(pattern: string): string {
+  assertPatternsInput(pattern);
+  return pattern.replaceAll(POSIX_UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
+}
+
+export const escapePath = os.platform() === 'win32' ? escapeWindowsPath : escapePosixPath;

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,7 +232,7 @@ export function globSync(patternsOrOptions: string | string[] | GlobOptions, opt
  */
 const UNESCAPED_GLOB_SYMBOLS_RE =
   os.platform() === 'win32'
-    ? /(?<escape>\\?)(?<symbols>[()[\]{}]|^!|[!+@](?=\())/g
-    : /(?<escape>\\?)(?<symbols>[()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
+    ? /(\\?)([()[\]{}]|^!|[!+@](?=\())/g
+    : /(\\?)([()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
 
 export const escapePath = (pattern: string): string => pattern.replace(UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,6 +235,4 @@ const UNESCAPED_GLOB_SYMBOLS_RE =
     ? /(?<escape>\\?)(?<symbols>[()[\]{}]|^!|[!+@](?=\())/g
     : /(?<escape>\\?)(?<symbols>[()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
 
-export function escapePath(pattern: string): string {
-  return pattern.replaceAll(UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
-}
+export const escapePath = (pattern: string): string => pattern.replaceAll(UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,8 +236,5 @@ const UNESCAPED_GLOB_SYMBOLS_RE =
     : /(?<escape>\\?)(?<symbols>[()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
 
 export function escapePath(pattern: string): string {
-  if (typeof pattern !== 'string' || pattern === '') {
-    throw new TypeError('Patterns must be a string (non empty) or an array of strings')
-  }
   return pattern.replaceAll(UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,8 +230,9 @@ export function globSync(patternsOrOptions: string | string[] | GlobOptions, opt
  * Posix: ()*?[]{|}, !+@ before (, ! at the beginning, \\ before non-special characters.
  * Windows: (){}[], !+@ before (, ! at the beginning.
  */
-const POSIX_UNESCAPED_GLOB_SYMBOLS_RE = /(?<escape>\\?)(?<symbols>[()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
-const WINDOWS_UNESCAPED_GLOB_SYMBOLS_RE = /(?<escape>\\?)(?<symbols>[()[\]{}]|^!|[!+@](?=\())/g;
+const UNESCAPED_GLOB_SYMBOLS_RE = os.platform() === 'win32'
+  ? /(?<escape>\\?)(?<symbols>[()[\]{}]|^!|[!+@](?=\())/g
+  : /(?<escape>\\?)(?<symbols>[()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
 
 function assertPatternsInput(input: unknown) {
   const source = ([] as unknown[]).concat(input);
@@ -244,5 +245,5 @@ function assertPatternsInput(input: unknown) {
 
 export function escapePath(pattern: string): string {
   assertPatternsInput(pattern);
-  return pattern.replaceAll(os.platform() === 'win32' ? WINDOWS_UNESCAPED_GLOB_SYMBOLS_RE : POSIX_UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
+  return pattern.replaceAll(UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,16 +234,11 @@ const UNESCAPED_GLOB_SYMBOLS_RE = os.platform() === 'win32'
   ? /(?<escape>\\?)(?<symbols>[()[\]{}]|^!|[!+@](?=\())/g
   : /(?<escape>\\?)(?<symbols>[()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
 
-function assertPatternsInput(input: unknown) {
-  const source = ([] as unknown[]).concat(input);
+export function escapePath(pattern: string): string {
+  const source = ([] as unknown[]).concat(pattern);
   const isValidSource = source.every(item => typeof item === 'string' && item !== '');
-
   if (!isValidSource) {
     throw new TypeError('Patterns must be a string (non empty) or an array of strings');
   }
-}
-
-export function escapePath(pattern: string): string {
-  assertPatternsInput(pattern);
   return pattern.replaceAll(UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,4 +235,4 @@ const UNESCAPED_GLOB_SYMBOLS_RE =
     ? /(?<escape>\\?)(?<symbols>[()[\]{}]|^!|[!+@](?=\())/g
     : /(?<escape>\\?)(?<symbols>[()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
 
-export const escapePath = (pattern: string): string => pattern.replaceAll(UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
+export const escapePath = (pattern: string): string => pattern.replace(UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import * as os from 'node:os';
 import path, { posix } from 'node:path';
 import { type Options as FdirOptions, fdir } from 'fdir';
 import picomatch from 'picomatch';
@@ -223,16 +222,4 @@ export function globSync(patternsOrOptions: string | string[] | GlobOptions, opt
   return crawl(opts, cwd, true);
 }
 
-// code below derived from fast-glob under MIT license
-
-/**
- * All non-escaped special characters.
- * Posix: ()*?[]{|}, !+@ before (, ! at the beginning, \\ before non-special characters.
- * Windows: (){}[], !+@ before (, ! at the beginning.
- */
-const UNESCAPED_GLOB_SYMBOLS_RE =
-  os.platform() === 'win32'
-    ? /(\\?)([()[\]{}]|^!|[!+@](?=\())/g
-    : /(\\?)([()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
-
-export const escapePath = (pattern: string): string => pattern.replace(UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
+export { escapePath } from './utils.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,4 +252,4 @@ function escapePosixPath(pattern: string): string {
   return pattern.replaceAll(POSIX_UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
 }
 
-export const escapePath = os.platform() === 'win32' ? escapeWindowsPath : escapePosixPath;
+export const escapePath: (pattern: string) => string = os.platform() === 'win32' ? escapeWindowsPath : escapePosixPath;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,4 +15,4 @@ export const escapeWin32Path = (pattern: string): string => pattern.replace(WIN3
 
 export const escapePath: (pattern: string) => string = process.platform === 'win32' ? escapeWin32Path : escapePosixPath;
 
-//#endregion
+// #endregion

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,18 @@
+// #region escapePath
+
+/*
+  Matches the following unescaped symbols:
+  `(){}[]`, `!+@` before `(`, `!` at the beginning,
+  plus the following platform-specific symbols:
+
+  Posix: `*?|`, `\` before non-special characters.
+*/
+const POSIX_UNESCAPED_GLOB_SYMBOLS = /(?<!\\)([()[\]{}*?|]|^!|[!+@](?=\()|\\(?![()[\]{}!*+?@|]))/g;
+const WIN32_UNESCAPED_GLOB_SYMBOLS = /(?<!\\)([()[\]{}]|^!|[!+@](?=\())/g;
+
+export const escapePosixPath = (pattern: string): string => pattern.replace(POSIX_UNESCAPED_GLOB_SYMBOLS, '\\$&');
+export const escapeWin32Path = (pattern: string): string => pattern.replace(WIN32_UNESCAPED_GLOB_SYMBOLS, '\\$&');
+
+export const escapePath: (pattern: string) => string = process.platform === 'win32' ? escapeWin32Path : escapePosixPath;
+
+//#endregion

--- a/test/escapePath.test.ts
+++ b/test/escapePath.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { escapePosixPath, escapeWin32Path } from '../src/utils.ts';
+
+for (const platform of ['win32', 'posix']) {
+  const escapePath = platform === 'posix' ? escapePosixPath : escapeWin32Path;
+
+  describe(`escapePath (${platform})`, () => {
+    test("doesn't add backslashes to already escaped patterns", () => {
+      assert.strictEqual(escapeWin32Path('\\['), '\\[');
+
+      if (platform === 'posix') {
+        assert.strictEqual(escapePath('\\|'), '\\|');
+      }
+    });
+
+    test("doesn't add wrong backslashes", () => {
+      assert.strictEqual(escapePath('hi!@+'), 'hi!@+');
+    });
+
+    test('correctly escapes characters', () => {
+      assert.strictEqual(escapePath('!nox'), '\\!nox');
+      assert.strictEqual(escapePath('hi+(@(!())))'), 'hi\\+\\(\\@\\(\\!\\(\\)\\)\\)\\)');
+
+      if (platform === 'posix') {
+        assert.strictEqual(escapePath('\\'), '\\\\');
+        assert.strictEqual(escapePath('meo*w'), 'meo\\*w');
+      } else if (platform === 'win32') {
+        assert.strictEqual(
+          escapePath('C:\\Users\\meeee\\New Folder (1)\\**'),
+          'C:\\Users\\meeee\\New Folder \\(1\\)\\**'
+        );
+      }
+    });
+  });
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
+import * as os from 'node:os';
 import path from 'node:path';
 import { after, test } from 'node:test';
 import { createFixture } from 'fs-fixture';
-import { glob, globSync } from '../src/index.ts';
+import { escapePath, glob, globSync } from '../src/index.ts';
 
 const fixture = await createFixture({
   a: {
@@ -263,3 +264,21 @@ test('sync with empty array matches nothing', () => {
   const files = globSync({ patterns: [] });
   assert.deepEqual(files.sort(), []);
 });
+
+if (os.platform() === 'win32') {
+  test('win32 .escapePath', () => {
+    const expected = 'C:\\Program Files \\(x86\\)\\**\\*';
+
+    const actual = escapePath('C:\\Program Files (x86)\\**\\*');
+
+    assert.strictEqual(actual, expected);
+  });  
+} else {
+  test('posix .escapePath', () => {
+    const expected = '/directory/\\*\\*/\\*';
+
+    const actual = escapePath('/directory/*\\*/*');
+
+    assert.strictEqual(actual, expected);
+  });
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,9 +1,8 @@
 import assert from 'node:assert/strict';
-import * as os from 'node:os';
 import path from 'node:path';
 import { after, test } from 'node:test';
 import { createFixture } from 'fs-fixture';
-import { escapePath, glob, globSync } from '../src/index.ts';
+import { glob, globSync } from '../src/index.ts';
 
 const fixture = await createFixture({
   a: {
@@ -200,7 +199,7 @@ test('absolute + empty commonPath', async () => {
 });
 
 test('works with non-absolute cwd', async () => {
-  const files = await glob({ patterns: ['*.test.ts'], cwd: 'test' });
+  const files = await glob({ patterns: ['index.test.ts'], cwd: 'test' });
   assert.deepEqual(files.sort(), ['index.test.ts']);
 });
 
@@ -264,21 +263,3 @@ test('sync with empty array matches nothing', () => {
   const files = globSync({ patterns: [] });
   assert.deepEqual(files.sort(), []);
 });
-
-if (os.platform() === 'win32') {
-  test('win32 .escapePath', () => {
-    const expected = 'C:\\Program Files \\(x86\\)\\**\\*';
-
-    const actual = escapePath('C:\\Program Files (x86)\\**\\*');
-
-    assert.strictEqual(actual, expected);
-  });
-} else {
-  test('posix .escapePath', () => {
-    const expected = '/directory/\\*\\*/\\*';
-
-    const actual = escapePath('/directory/*\\*/*');
-
-    assert.strictEqual(actual, expected);
-  });
-}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -272,7 +272,7 @@ if (os.platform() === 'win32') {
     const actual = escapePath('C:\\Program Files (x86)\\**\\*');
 
     assert.strictEqual(actual, expected);
-  });  
+  });
 } else {
   test('posix .escapePath', () => {
     const expected = '/directory/\\*\\*/\\*';


### PR DESCRIPTION
closes #29

I didn't copy any tests over yet as I thought it was worth deciding on a couple of other questions first before investing more time into it

I wasn't quite sure how to handle the license. This project is ISC licensed and fast-glob is MIT licensed. The two licenses are extremely similar, but I think it'd be simplest if they used the same license. Would you be okay with switch to the MIT license? If so, we should probably also confirm with the other contributors to this project, which luckily shouldn't be hard to do given that it's still a relatively new project

I just put everything into the index file for now since it's still relatively small, but would you prefer these to live in a separate file? I took a few liberties in making minor modifications to the `fast-glob` code to keep things simpler. E.g. I replaced their `utils.string.isEmpty` method with directly doing `item !== ''` so that there were fewer methods to copy over - and I also find it easier to read without the extra layer of indirection.