### PR TITLE
simplify dual publish

### DIFF
--- a/dist-esm/index.d.mts
+++ b/dist-esm/index.d.mts
@@ -1,0 +1,1 @@
+export * from '../dist/index.d.ts';

--- a/dist-esm/index.mjs
+++ b/dist-esm/index.mjs
@@ -1,0 +1,1 @@
+export * from '../dist/index.js';

--- a/package.json
+++ b/package.json
@@ -14,15 +14,16 @@
     "typecheck": "tsc --noEmit"
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist-esm/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.mjs",
+    "import": "./dist-esm/index.mjs",
     "require": "./dist/index.js"
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "dist-esm"
   ],
   "author": "Superchupu",
   "license": "ISC",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,8 +4,7 @@ export default defineConfig({
   clean: true,
   dts: true,
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['cjs'],
   platform: 'node',
-  sourcemap: true,
   target: 'node12'
 }) as Options;


### PR DESCRIPTION
I created the PR as an example for dual publishing, you can tweak or reject this if you prefer another way.

I also removed sourcemaps since the code is small enough that it doesn't bring a big benefit.

Before:
```bash
bjorn@Bjorns-MacBook-Pro tinyglobby % npm pack
npm notice
npm notice 📦  tinyglobby@0.2.6
npm notice Tarball Contents
npm notice 750B LICENSE
npm notice 2.4kB README.md
npm notice 683B dist/index.d.mts
npm notice 683B dist/index.d.ts
npm notice 7.3kB dist/index.js
npm notice 11.1kB dist/index.js.map
npm notice 5.5kB dist/index.mjs
npm notice 11.0kB dist/index.mjs.map
npm notice 1.6kB package.json
npm notice Tarball Details
npm notice name: tinyglobby
npm notice version: 0.2.6
npm notice filename: tinyglobby-0.2.6.tgz
npm notice package size: 8.1 kB
npm notice unpacked size: 41.0 kB
npm notice shasum: fdd31e6e8d773ceaa43fe0663f0f137760279e7b
npm notice integrity: sha512-tXPSUp+D6KyXb[...]BttqWnvknHY6w==
npm notice total files: 9
npm notice
tinyglobby-0.2.6.tgz
```

After:
```bash
bjorn@Bjorns-MacBook-Pro tinyglobby % npm pack
npm notice
npm notice 📦  tinyglobby@0.2.6
npm notice Tarball Contents
npm notice 750B LICENSE
npm notice 2.4kB README.md
npm notice 36B dist-esm/index.d.mts
npm notice 34B dist-esm/index.mjs
npm notice 683B dist/index.d.ts
npm notice 7.3kB dist/index.js
npm notice 1.7kB package.json
npm notice Tarball Details
npm notice name: tinyglobby
npm notice version: 0.2.6
npm notice filename: tinyglobby-0.2.6.tgz
npm notice package size: 4.8 kB
npm notice unpacked size: 12.9 kB
npm notice shasum: f6f8c96ef2c2e70fc290b75ded38ba3cf836ad52
npm notice integrity: sha512-+8JiJPpa3s7/q[...]cV8rYYFVg+YxQ==
npm notice total files: 7
npm notice
tinyglobby-0.2.6.tgz
```