### PR TITLE
early out if pattern array is empty

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,10 @@ function processPath(path: string, cwd: string, root: string, isDirectory: boole
 function crawl(options: GlobOptions, cwd: string, sync: false): Promise<string[]>;
 function crawl(options: GlobOptions, cwd: string, sync: true): string[];
 function crawl(options: GlobOptions, cwd: string, sync: boolean) {
+  if (Array.isArray(options.patterns) && options.patterns.length === 0) {
+    return [];
+  }
+
   const properties = {
     root: cwd,
     commonPath: null,


### PR DESCRIPTION
While testing Vite beta with Astro, I noticed that if passed an empty patterns array, `tinyglobby` is still crawling all the files even though the result will always be empty. The result seems to be the same with `fast-glob`.

This PR creates a fast path to early out if so. I'm not sure if this is the right place to put it, or if you'd consider this an edge case not worth handling.

I'm happy to fix this on Vite side too. It was happening in [this Vite code](https://github.com/vitejs/vite/blob/d4e0442f9d6adc70b72ea0713dc8abb4b1f75ae4/packages/vite/src/node/server/warmup.ts#L73-L79) where we passed an empty patterns array without an `ignore` config, so it's crawling everything including `node_modules` stalling the process.