### PR TITLE
improve and completely rework exclude optimizer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,20 +54,20 @@ function normalizePattern(
       properties.depthOffset = -(parentDirectoryMatch[0].length + 1) / 3;
     }
   } else if (!isIgnore && properties.depthOffset >= 0) {
-    const current = result.split('/');
-    properties.commonPath ??= current;
+    const parts = splitPattern(result);
+    properties.commonPath ??= parts;
 
     const newCommonPath = [];
 
-    for (let i = 0; i < Math.min(properties.commonPath.length, current.length); i++) {
-      const part = current[i];
+    for (let i = 0; i < Math.min(properties.commonPath.length, parts.length); i++) {
+      const part = parts[i];
 
-      if (part === '**' && !current[i + 1]) {
+      if (part === '**' && !parts[i + 1]) {
         newCommonPath.pop();
         break;
       }
 
-      if (part !== properties.commonPath[i] || isDynamicPattern(part) || i === current.length - 1) {
+      if (part !== properties.commonPath[i] || isDynamicPattern(part) || i === parts.length - 1) {
         break;
       }
 
@@ -115,7 +115,7 @@ function processPatterns(
     if (!pattern.startsWith('!') || pattern[1] === '(') {
       const newPattern = normalizePattern(pattern, expandDirectories, cwd, properties, false);
       matchPatterns.push(newPattern);
-      const split = newPattern.split('/');
+      const split = splitPattern(newPattern);
 
       transformed.push(
         split
@@ -134,6 +134,12 @@ function processPatterns(
   }
 
   return { match: matchPatterns, ignore: ignorePatterns, transformed };
+}
+
+// if a pattern has no slashes outside glob symbols, results.parts is []
+function splitPattern(path: string) {
+  const result = picomatch.scan(path, { parts: true });
+  return result.parts?.length ? result.parts : [path];
 }
 
 // TODO: this is slow, find a better way to do this

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,8 +15,9 @@ export function getPartialMatcher(patterns: string[], options?: PartialMatcherOp
     for (let i = 0; i < patterns.length; i++) {
       const patternParts = splitPattern(patterns[i]);
       const regex = regexes[i];
+      const minParts = Math.min(inputParts.length, patternParts.length);
       let j = 0;
-      while (j < inputParts.length) {
+      while (j < minParts) {
         const part = patternParts[j];
 
         // handling slashes in parts is very hard, not even fast-glob does it

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -307,6 +307,11 @@ test('matching files with specific naming pattern', async () => {
   assert.deepEqual(files.sort(), ['a/a.txt', 'a/b.txt', 'b/a.txt', 'b/b.txt']);
 });
 
+test('dynamic patterns that include slashes inside parts', async () => {
+  const files = await glob({ patterns: ['{.a/a,a}/a.txt'], cwd });
+  assert.deepEqual(files.sort(), ['.a/a/a.txt', 'a/a.txt']);
+});
+
 test('using extglob patterns', async () => {
   const files = await glob({ patterns: ['a/*(a|b).txt'], cwd });
   assert.deepEqual(files.sort(), ['a/a.txt', 'a/b.txt']);

--- a/test/utils/partial-matcher.test.ts
+++ b/test/utils/partial-matcher.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import test, { describe } from 'node:test';
+import { getPartialMatcher } from '../../src/utils.ts';
+
+describe('getPartialMatcher', () => {
+  test('works with exact path', () => {
+    const matcher = getPartialMatcher(['test/utils/a']);
+    assert.ok(matcher('test/utils/a'));
+  });
+
+  test('works with partial path', () => {
+    const matcher = getPartialMatcher(['test/utils/a']);
+    assert.ok(matcher('test/utils'));
+  });
+
+  test("static pattern doesn't give false positives", () => {
+    const matcher = getPartialMatcher(['test/utils/a']);
+    assert.ok(!matcher('test/utils/b'));
+    assert.ok(!matcher('test/tests'));
+    assert.ok(!matcher('src'));
+  });
+
+  test('works with dynamic pattern', () => {
+    const matcher = getPartialMatcher(['test/util?/a']);
+    assert.ok(matcher('test/utils'));
+  });
+
+  test('works with brace expansion', () => {
+    const matcher = getPartialMatcher(['test/{utils,tests}/a']);
+    assert.ok(matcher('test/utils/a'));
+    assert.ok(matcher('test/tests/a'));
+    assert.ok(matcher('test/utils'));
+    assert.ok(matcher('test/tests'));
+
+    assert.ok(!matcher('test/other/a'));
+    assert.ok(!matcher('test/other'));
+  });
+
+  test('works with **', () => {
+    const matcher = getPartialMatcher(['test/utils/**']);
+    assert.ok(matcher('test'));
+    assert.ok(matcher('test/utils'));
+    assert.ok(matcher('test/utils/a'));
+    assert.ok(!matcher('test/tests/a'));
+  });
+
+  test("** doesn't match ..", () => {
+    const matcher = getPartialMatcher(['**']);
+    assert.ok(!matcher('..'));
+  });
+
+  test('for now treats parts with / as **', () => {
+    const matcher = getPartialMatcher(['test/{utils/a,b}']);
+    assert.ok(matcher('test'));
+    assert.ok(matcher('test/utils'));
+    assert.ok(matcher('test/utils/a'));
+
+    // only happens when treating it as **
+    assert.ok(matcher('test/notutils'));
+    assert.ok(matcher('test/notutils/a'));
+  });
+
+  test('works with weird parentheses combinations', () => {
+    const matcher = getPartialMatcher(['test/utils/(a)']);
+    assert.ok(matcher('test/utils/a'));
+    assert.ok(matcher('test/utils'));
+    assert.ok(!matcher('test/utils/c'));
+  });
+
+  test('dot: true', () => {
+    const matcher = getPartialMatcher(['test/utils/*/c'], { dot: true });
+    assert.ok(matcher('test/utils/a/c'));
+    assert.ok(matcher('test/utils/.a/c'));
+    assert.ok(matcher('test/utils'));
+  });
+
+  test('dot: false', () => {
+    const matcher = getPartialMatcher(['test/utils/*/c']);
+    assert.ok(matcher('test/utils/a/c'));
+    assert.ok(!matcher('test/utils/.a/c'));
+    assert.ok(matcher('test/utils'));
+  });
+
+  test('dot: false and **', () => {
+    const matcher = getPartialMatcher(['test/utils/**/c']);
+    assert.ok(matcher('test/utils/a/c'));
+    assert.ok(!matcher('test/utils/.a/c'));
+    assert.ok(matcher('test/utils'));
+  });
+});

--- a/test/utils/partial-matcher.test.ts
+++ b/test/utils/partial-matcher.test.ts
@@ -87,4 +87,37 @@ describe('getPartialMatcher', () => {
     assert.ok(!matcher('test/utils/.a/c'));
     assert.ok(matcher('test/utils'));
   });
+
+  test('path initially matching pattern but more input than pattern parts', () => {
+    const matcher = getPartialMatcher(['test/utils/a']);
+    assert.ok(!matcher('test/utils/a/c'));
+  });
+
+  test('multiple patterns', () => {
+    const matcher = getPartialMatcher(['test/util?/a', 'test/utils/a/c']);
+    assert.ok(matcher('test/utils/a/c'));
+    assert.ok(matcher('test/utilg/a'));
+    assert.ok(matcher('test/utilg'));
+    assert.ok(!matcher('test/utilg/a/c'));
+  });
+
+  test('..', () => {
+    const matcher = getPartialMatcher(['../test/util?/a']);
+    assert.ok(matcher('..'));
+    assert.ok(matcher('../test/utilg/a'));
+    assert.ok(!matcher('a/test/utilg/a'));
+    assert.ok(!matcher('test/utilg/a'));
+  });
+
+  test('.. mixed with normal pattern', () => {
+    const matcher = getPartialMatcher(['../test/util?/a', 'src/utils/a']);
+    assert.ok(matcher('..'));
+    assert.ok(matcher('../test/utilg/a'));
+    assert.ok(!matcher('a/test/utilg/a'));
+    assert.ok(!matcher('test/utilg/a'));
+
+    assert.ok(matcher('src'));
+    assert.ok(matcher('src/utils'));
+    assert.ok(!matcher('src/gaming'));
+  });
 });


### PR DESCRIPTION
shorter and probably faster implementation :tada: also improves optimization for patterns that end with `**`

~~needs some work, this implementation (and the previous one) don't work well with patterns that wrap `/` in things like `*(src/index.ts)`. see https://github.com/SuperchupuDev/tinyglobby/pull/76#issuecomment-2599331217~~ disabled optimizations in those cases for now

also closes #79 once the above is solved, and makes tests from #80 work :-)

EDIT: REWRITTEN FROM THE GROUND UP with a different approach to avoid the many edge cases it used to have