### PR TITLE
add basic directory tests

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -386,3 +386,18 @@ test('sync with empty array matches nothing', () => {
   const files = globSync({ patterns: [] });
   assert.deepEqual(files.sort(), []);
 });
+
+test('*', async () => {
+  const files = await glob({ patterns: ['./*'], cwd, onlyDirectories: true, expandDirectories: false });
+  assert.deepEqual(files.sort(), ['a/', 'b/']);
+});
+
+test('.a/*', async () => {
+  const files = await glob({ patterns: ['.a/*'], cwd, onlyDirectories: true, expandDirectories: false });
+  assert.deepEqual(files.sort(), ['.a/a/']);
+});
+
+test('. + .a/*', async () => {
+  const files = await glob({ patterns: ['.', '.a/*'], cwd, onlyDirectories: true, expandDirectories: false });
+  assert.deepEqual(files.sort(), ['.', '.a/a/']);
+});


### PR DESCRIPTION
When trying out tinyglobby, I noticed it doesn't return directories the way I'd expect. So I wonder whether using the single star like this is invalid syntax and expected behavior. Is there a way with different syntax and/or options to make the tests pass already?

Or should we try and make this happen? :)