### PR TITLE
fix: avoid full scan with ignore empty string array, fixes #85

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ function processPatterns(
   const ignorePatterns: string[] = [];
 
   for (const pattern of ignore) {
+    if (!pattern) continue;
     // don't handle negated patterns here for consistency with fast-glob
     if (!pattern.startsWith('!') || pattern[1] === '(') {
       const newPattern = normalizePattern(pattern, expandDirectories, cwd, properties, true);
@@ -112,6 +113,7 @@ function processPatterns(
 
   const transformed: string[] = [];
   for (const pattern of patterns) {
+    if (!pattern) continue;
     if (!pattern.startsWith('!') || pattern[1] === '(') {
       const newPattern = normalizePattern(pattern, expandDirectories, cwd, properties, false);
       matchPatterns.push(newPattern);

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,9 @@ function processPatterns(
   const ignorePatterns: string[] = [];
 
   for (const pattern of ignore) {
-    if (!pattern) continue;
+    if (!pattern) {
+      continue;
+    }
     // don't handle negated patterns here for consistency with fast-glob
     if (!pattern.startsWith('!') || pattern[1] === '(') {
       const newPattern = normalizePattern(pattern, expandDirectories, cwd, properties, true);
@@ -113,7 +115,9 @@ function processPatterns(
 
   const transformed: string[] = [];
   for (const pattern of patterns) {
-    if (!pattern) continue;
+    if (!pattern) {
+      continue;
+    }
     if (!pattern.startsWith('!') || pattern[1] === '(') {
       const newPattern = normalizePattern(pattern, expandDirectories, cwd, properties, false);
       matchPatterns.push(newPattern);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -82,7 +82,7 @@ test('ignore option as string', async () => {
 
 test('ignore option with an empty string array', async () => {
   const files = await glob({ patterns: ['**/a.txt'], ignore: [''], cwd });
-  assert.deepEqual(files.sort(), ['a/a.txt']);
+  assert.deepEqual(files.sort(), ['a/a.txt', 'b/a.txt']);
 });
 
 test('caseSensitiveMatch', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -80,6 +80,11 @@ test('ignore option as string', async () => {
   assert.deepEqual(files.sort(), ['a/a.txt']);
 });
 
+test('ignore option with an empty string array', async () => {
+  const files = await glob({ patterns: ['**/a.txt'], ignore: [''], cwd });
+  assert.deepEqual(files.sort(), ['a/a.txt']);
+});
+
 test('caseSensitiveMatch', async () => {
   const files = await glob({ patterns: ['**/A.TXT'], caseSensitiveMatch: false, cwd });
   assert.deepEqual(files.sort(), ['a/a.txt', 'b/a.txt']);


### PR DESCRIPTION
fixes #85

This PR fixes issue #85 and produces same result as fast-glob. Side note, I couldn't run the test on my Windows machine, though I assume the test is valid (I'll have to wait and see if it passes in the CI).

without the code change, it seems to do a full scan and I'm getting this pattern added

![image](https://github.com/user-attachments/assets/612c1128-a712-4c03-a26a-e8b57748919d)

For fast-glob comparison, below is the testing code in my super small folder (only 6 files in it)... as shown below it only seems to do a full scan in tinyglobby, not in fast-glob, as per this perf log

testing code
```js
console.time('fastglob');
const fgOut = fg.globSync(sources, { ignore: [''] });
console.timeEnd('fastglob');

console.time('tinyglobby');
const tgOut = globSync(sources, { ignore: [''] });
console.timeEnd('tinyglobby');

console.log(fgOut, tgOut);
```
the output is
```sh
fastglob: 6.6591796875 ms
fastglob: 6.824ms

tinyglobby: 53099.125 ms
tinyglobby: 53.099s
```

the output is also working as expected in fast-glob but returns nothing with tinyglobby. Note that the folder I'm testing with is very small, it only has 5 testing items as shown below (in other words, fast-glob returns all files because the ignore is an empty string array, but tinyglobby returns nothing which is unexpected)
```sh
# fast-glob output
['src/assets/i18n/en.json', 'src/assets/i18n/fr.json', 'src/assets/i18n/some/inside.txt', 'src/assets/i18n/some/folder/file1.txt', 'src/assets/i18n/some/other/file2.txt']

# tinyglobby output
[]
```