### PR TITLE
docs: update list of consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@ globSync(['src/**/*.ts'], { ignore: ['**/*.d.ts'] });
 `tinyglobby` is downloaded many times by projects all around the world. Here's a list of notable projects that use it:
 
 <!-- should be sorted by weekly download count -->
-- [`eslint-import-resolver-typescript`](https://github.com/import-js/eslint-import-resolver-typescript)
 - [`vite`](https://github.com/vitejs/vite)
+- [`eslint-import-resolver-typescript`](https://github.com/import-js/eslint-import-resolver-typescript)
 - [`vitest`](https://github.com/vitest-dev/vitest)
 - [`ts-morph`](https://github.com/dsherret/ts-morph)
 - [`nx`](https://github.com/nrwl/nx)
 - [`sort-package-json`](https://github.com/keithamus/sort-package-json)
+- [`unimport`](https://github.com/unjs/unimport)
 - [`tsup`](https://github.com/egoist/tsup)
 - [`vite-plugin-checker`](https://github.com/fi3ework/vite-plugin-checker)
 - [`cspell`](https://github.com/streetsidesoftware/cspell)
@@ -63,6 +64,6 @@ globSync(['src/**/*.ts'], { ignore: ['**/*.d.ts'] });
 - [`postcss-mixins`](https://github.com/postcss/postcss-mixins)
 - [`unocss`](https://github.com/unocss/unocss)
 - [`vitepress`](https://github.com/vuejs/vitepress)
-- [`pkg.pr.new`](https://github.com/stackblitz-labs/pkg.pr.new)
+- [`pkg-pr-new`](https://github.com/stackblitz-labs/pkg.pr.new)
 - Your own project? [Open an issue](https://github.com/SuperchupuDev/tinyglobby/issues)
 if you feel like this list is incomplete.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ globSync(['src/**/*.ts'], { ignore: ['**/*.d.ts'] });
 
 <!-- should be sorted by weekly download count -->
 - [`vite`](https://github.com/vitejs/vite)
+- [`node-gyp`](https://github.com/nodejs/node-gyp)
 - [`eslint-import-resolver-typescript`](https://github.com/import-js/eslint-import-resolver-typescript)
 - [`vitest`](https://github.com/vitest-dev/vitest)
 - [`ts-morph`](https://github.com/dsherret/ts-morph)
@@ -59,8 +60,6 @@ globSync(['src/**/*.ts'], { ignore: ['**/*.d.ts'] });
 - [`vite-plugin-checker`](https://github.com/fi3ework/vite-plugin-checker)
 - [`cspell`](https://github.com/streetsidesoftware/cspell)
 - [`nuxt`](https://github.com/nuxt/nuxt)
-- [`json-schema-to-typescript`](https://github.com/bcherny/json-schema-to-typescript)
-- [`vite-plugin-pwa`](https://github.com/vite-pwa/vite-plugin-pwa)
 - [`postcss-mixins`](https://github.com/postcss/postcss-mixins)
 - [`unocss`](https://github.com/unocss/unocss)
 - [`vitepress`](https://github.com/vuejs/vitepress)


### PR DESCRIPTION
- vite should be listed first
- pkg-pr-new has dashes on npm
- node-gyp and unimport have now adopted tinyglobby
- removed a couple less used ones to keep the list from getting too long