### PR TITLE
fix: correctly join paths when `cwd: '/'`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ function normalizePattern(
     props.depthOffset = newCommonPath.length;
     props.commonPath = newCommonPath;
 
-    props.root = newCommonPath.length > 0 ? `${cwd}/${newCommonPath.join('/')}` : cwd;
+    props.root = newCommonPath.length > 0 ? path.posix.join(cwd, ...newCommonPath) : cwd;
   }
 
   return result;


### PR DESCRIPTION
closes https://github.com/SuperchupuDev/tinyglobby/issues/94