### PR TITLE
chore: set onlyBuiltDependencies for pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,11 @@
     "access": "public",
     "provenance": true
   },
-  "packageManager": "pnpm@10.8.1"
+  "packageManager": "pnpm@10.8.1",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@biomejs/biome",
+      "esbuild"
+    ]
+  }
 }


### PR DESCRIPTION
You have to tell the latest version of pnpm that it's allowed to run the post-install scripts for these packages or it will complain when you do `pnpm install`