### PR TITLE
chore: add onlyBuiltDependencies config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - '@biomejs/biome'
+  - esbuild


### PR DESCRIPTION
After pnpm 10, lifecycle scripts of dependencies are not executed during installation by default! [pnpm/pnpm@v10.0.0 (release)](https://github.com/pnpm/pnpm/releases/tag/v10.0.0)