### PR TITLE
feat: log supports multiple colors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import path, { posix } from 'node:path';
 import { type Options as FdirOptions, fdir } from 'fdir';
 import picomatch from 'picomatch';
-import { chalkLog, escapePath, getPartialMatcher, isDynamicPattern, log, splitPattern } from './utils.ts';
+import { coloredLog, escapePath, getPartialMatcher, isDynamicPattern, log, splitPattern } from './utils.ts';
 
 const PARENT_DIRECTORY = /^(\/?\.\.)+/;
 const ESCAPING_BACKSLASHES = /\\(?=[()[\]{}!*+?@|])/g;
@@ -207,7 +207,7 @@ function crawl(options: GlobOptions, cwd: string, sync: boolean) {
             const matches = matcher(path);
 
             if (matches) {
-              chalkLog(`matched ${path}`, 'matched');
+              coloredLog(`matched ${path}`, 'matched');
             }
 
             return matches;
@@ -220,9 +220,9 @@ function crawl(options: GlobOptions, cwd: string, sync: boolean) {
           const skipped = (relativePath !== '.' && !partialMatcher(relativePath)) || ignore(relativePath);
 
           if (skipped) {
-            chalkLog(`skipped ${p}`, 'skipped');
+            coloredLog(`skipped ${p}`, 'skipped');
           } else {
-            chalkLog(`crawling ${p}`, 'crawling');
+            coloredLog(`crawling ${p}`, 'crawling');
           }
 
           return skipped;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import path, { posix } from 'node:path';
 import { type Options as FdirOptions, fdir } from 'fdir';
 import picomatch from 'picomatch';
-import { escapePath, getPartialMatcher, isDynamicPattern, log, splitPattern } from './utils.ts';
+import { chalkLog, escapePath, getPartialMatcher, isDynamicPattern, log, splitPattern } from './utils.ts';
 
 const PARENT_DIRECTORY = /^(\/?\.\.)+/;
 const ESCAPING_BACKSLASHES = /\\(?=[()[\]{}!*+?@|])/g;
@@ -207,7 +207,7 @@ function crawl(options: GlobOptions, cwd: string, sync: boolean) {
             const matches = matcher(path);
 
             if (matches) {
-              log(`matched ${path}`);
+              chalkLog(`matched ${path}`, 'matched');
             }
 
             return matches;
@@ -220,9 +220,9 @@ function crawl(options: GlobOptions, cwd: string, sync: boolean) {
           const skipped = (relativePath !== '.' && !partialMatcher(relativePath)) || ignore(relativePath);
 
           if (skipped) {
-            log(`skipped ${p}`);
+            chalkLog(`skipped ${p}`, 'skipped');
           } else {
-            log(`crawling ${p}`);
+            chalkLog(`crawling ${p}`, 'crawling');
           }
 
           return skipped;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -150,15 +150,15 @@ export function isDynamicPattern(pattern: string, options?: { caseSensitiveMatch
 export function log(...tasks: unknown[]): void {
   console.log(`[tinyglobby ${new Date().toLocaleTimeString('es')}]`, ...tasks);
 }
-export function chalkLog(msg: string, type: string): void {
-  const _chalk = {
+export function coloredLog(msg: string, type: 'matched' | 'skipped' | 'crawling'): void {
+  const colors = {
     matched: '\x1b[32m',
     skipped: '\x1b[90m',
     crawling: '\x1b[34m'
   };
-  const chalk = _chalk[type as keyof typeof _chalk];
-  if (chalk) {
-    console.log(`${chalk}%s\x1b[0m`, `[tinyglobby ${new Date().toLocaleTimeString('es')}]${msg}`);
+  const color = colors[type as keyof typeof colors];
+  if (color) {
+    console.log(`${color}%s\x1b[0m`, `[tinyglobby ${new Date().toLocaleTimeString('es')}]${msg}`);
     return;
   }
   console.log(`[tinyglobby ${new Date().toLocaleTimeString('es')}]`, msg);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -150,4 +150,17 @@ export function isDynamicPattern(pattern: string, options?: { caseSensitiveMatch
 export function log(...tasks: unknown[]): void {
   console.log(`[tinyglobby ${new Date().toLocaleTimeString('es')}]`, ...tasks);
 }
+export function chalkLog(msg: string, type: string): void {
+  const _chalk = {
+    matched: '\x1b[32m',
+    skipped: '\x1b[90m',
+    crawling: '\x1b[34m'
+  };
+  const chalk = _chalk[type as keyof typeof _chalk];
+  if (chalk) {
+    console.log(`${chalk}%s\x1b[0m`, `[tinyglobby ${new Date().toLocaleTimeString('es')}]${msg}`);
+    return;
+  }
+  console.log(`[tinyglobby ${new Date().toLocaleTimeString('es')}]`, msg);
+}
 // #endregion


### PR DESCRIPTION
Add colors to distinguish different types of logs to facilitate quick access to information.

|before|after|
|---|--------|
|![image](https://github.com/user-attachments/assets/e2cb8fd9-ad20-4c04-9fe6-5d4abf1d5aad)|![image](https://github.com/user-attachments/assets/16869880-722a-4a16-98ad-281fd4813d58)|