### PR TITLE
fix: compatible patterns start with `!/`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ function normalizePattern(
 
   const parentDirectoryMatch = PARENT_DIRECTORY.exec(result);
   if (parentDirectoryMatch?.[0]) {
-    const potentialRoot = posix.join(cwd, parentDirectoryMatch[0]);
+    const potentialRoot = path.join(cwd, parentDirectoryMatch[0]);
     if (props.root.length > potentialRoot.length) {
       props.root = potentialRoot;
       props.depthOffset = -(parentDirectoryMatch[0].length + 1) / 3;
@@ -82,7 +82,7 @@ function normalizePattern(
     props.depthOffset = newCommonPath.length;
     props.commonPath = newCommonPath;
 
-    props.root = newCommonPath.length > 0 ? path.posix.join(cwd, ...newCommonPath) : cwd;
+    props.root = newCommonPath.length > 0 ? path.join(cwd, ...newCommonPath) : cwd;
   }
 
   return result;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -65,6 +65,11 @@ test('negative patterns', async () => {
   assert.deepEqual(files.sort(), ['a/a.txt']);
 });
 
+test('negative patterns with starts with !/', async () => {
+  const files = await glob({ patterns: ['**/a.txt', '!/b/a.txt'], cwd });
+  assert.deepEqual(files.sort(), ['a/a.txt', 'b/a.txt']);
+});
+
 test('patterns as string', async () => {
   const files = await glob('a/a.txt', { cwd });
   assert.deepEqual(files.sort(), ['a/a.txt']);


### PR DESCRIPTION
After a local comparison test, if the value of patterns is `['packages/**', '!/packages/test/**']`, the matching result seems to ignore the second value.

On the Mac system, the results of the two are consistent, as expected. However, on the Windows platform, the output of fast-glob is consistent with that of the Mac platform, but tinyglobby outputs an empty array.