### PR TITLE
perf: faster formatting of paths

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -35,7 +35,8 @@
         "useEnumInitializers": "off",
         "useForOf": "error",
         "useNodeAssertStrict": "error",
-        "useShorthandAssign": "error"
+        "useShorthandAssign": "error",
+        "useTemplate": "off"
       },
       "suspicious": {
         "noEmptyBlockStatements": "error"

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,11 +146,6 @@ function processPatterns(
   return { match: matchPatterns, ignore: ignorePatterns };
 }
 
-// TODO: this is slow, find a better way to do this
-function getRelativePath(path: string, cwd: string, root: string) {
-  return posix.relative(cwd, `${root}/${path}`) || '.';
-}
-
 function processPath(path: string, cwd: string, root: string, isDirectory: boolean, absolute?: boolean) {
   const relativePath = absolute ? path.slice(root === '/' ? 1 : root.length + 1) || '.' : path;
 
@@ -158,13 +153,14 @@ function processPath(path: string, cwd: string, root: string, isDirectory: boole
     return isDirectory && relativePath !== '.' ? relativePath.slice(0, -1) : relativePath;
   }
 
-  return getRelativePath(relativePath, cwd, root);
+  return posix.relative(cwd, root + '/' + relativePath) || '.';
 }
 
 function formatPaths(paths: string[], cwd: string, root: string) {
+  const rootInCwd = root.startsWith(cwd + '/');
+  const relativeRoot = rootInCwd && root.slice(cwd.length + 1);
   for (let i = paths.length - 1; i >= 0; i--) {
-    const path = paths[i];
-    paths[i] = getRelativePath(path, cwd, root) + (!path || path.endsWith('/') ? '/' : '');
+    paths[i] = rootInCwd ? relativeRoot + '/' + paths[i] : posix.relative(cwd, root + '/' + paths[i]) || './';
   }
   return paths;
 }


### PR DESCRIPTION
this should be a lot faster:
- removes stripping and then re-adding `/`
- moves the most expensive calls to happen outside the `for` loop
- removes a function call
- replaces template literals with string concatenation

closes https://github.com/SuperchupuDev/tinyglobby/pull/130