### PR TITLE
fix negated bracket expressions

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,22 +1,16 @@
 import { posix } from 'node:path';
-import picomatch from 'picomatch';
+import picomatch, { type PicomatchOptions } from 'picomatch';
 
 const isWin = process.platform === 'win32';
 
 // #region PARTIAL MATCHER
-export interface PartialMatcherOptions {
-  dot?: boolean;
-  nocase?: boolean;
-  noglobstar?: boolean;
-}
-
 // can't use `Matcher` from picomatch as it requires a second argument since @types/picomatch v4
 type PartialMatcher = (test: string) => boolean;
 
 const ONLY_PARENT_DIRECTORIES = /^(\/?\.\.)+$/;
 
 // the result of over 4 months of figuring stuff out and a LOT of help
-export function getPartialMatcher(patterns: string[], options?: PartialMatcherOptions): PartialMatcher {
+export function getPartialMatcher(patterns: string[], options?: PicomatchOptions): PartialMatcher {
   // you might find this code pattern odd, but apparently it's faster than using `.push()`
   const patternsCount = patterns.length;
   const patternsParts: string[][] = Array(patternsCount);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -365,6 +365,11 @@ test('using extglob patterns', async () => {
   assert.deepEqual(files.sort(), ['a/a.txt', 'a/b.txt']);
 });
 
+test('using negated bracket expression', async () => {
+  const files = await glob('**/[!a].*', { cwd });
+  assert.deepEqual(files.sort(), ['a/b.txt', 'b/b.txt']);
+});
+
 test('pattern normalization', async () => {
   const files1 = await glob('a', { cwd });
   const files2 = await glob('a/', { cwd });


### PR DESCRIPTION
picomatch only supports it with `posix: true` for some reason

closes #149