### PR TITLE
feat: allow passing readonly types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,12 @@ import path, { posix } from 'node:path';
 import { type Options as FdirOptions, fdir } from 'fdir';
 import picomatch, { type PicomatchOptions } from 'picomatch';
 import {
-  isReadonlyArray,
   buildFormat,
   buildRelative,
   escapePath,
   getPartialMatcher,
   isDynamicPattern,
+  isReadonlyArray,
   log,
   splitPattern
 } from './utils.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import path, { posix } from 'node:path';
 import { type Options as FdirOptions, fdir } from 'fdir';
 import picomatch, { type PicomatchOptions } from 'picomatch';
 import {
+  isReadonlyArray,
   buildFormat,
   buildRelative,
   escapePath,
@@ -14,9 +15,6 @@ import {
 const PARENT_DIRECTORY = /^(\/?\.\.)+/;
 const ESCAPING_BACKSLASHES = /\\(?=[()[\]{}!*+?@|])/g;
 const BACKSLASHES = /\\/g;
-
-// The `Array.isArray` type guard doesn't work for readonly arrays.
-const isReadonlyArray: (arg: unknown) => arg is readonly unknown[] = Array.isArray;
 
 export interface GlobOptions {
   readonly absolute?: boolean;
@@ -310,17 +308,17 @@ export async function glob(
   return formatPaths(await crawler.withPromise(), relative);
 }
 
-export function globSync(patterns: string | string[], options?: Omit<GlobOptions, 'patterns'>): string[];
+export function globSync(patterns: string | readonly string[], options?: Omit<GlobOptions, 'patterns'>): string[];
 /**
  * @deprecated Provide patterns as the first argument instead.
  */
 export function globSync(options: GlobOptions): string[];
-export function globSync(patternsOrOptions: string | string[] | GlobOptions, options?: GlobOptions): string[] {
+export function globSync(patternsOrOptions: string | readonly string[] | GlobOptions, options?: GlobOptions): string[] {
   if (patternsOrOptions && options?.patterns) {
     throw new Error('Cannot pass patterns as both an argument and an option');
   }
 
-  const isModern = Array.isArray(patternsOrOptions) || typeof patternsOrOptions === 'string';
+  const isModern = isReadonlyArray(patternsOrOptions) || typeof patternsOrOptions === 'string';
   const opts = isModern ? options : patternsOrOptions;
   const patterns = isModern ? patternsOrOptions : patternsOrOptions.patterns;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,23 +17,23 @@ const ESCAPING_BACKSLASHES = /\\(?=[()[\]{}!*+?@|])/g;
 const BACKSLASHES = /\\/g;
 
 export interface GlobOptions {
-  readonly absolute?: boolean;
-  readonly caseSensitiveMatch?: boolean;
-  readonly cwd?: string;
-  readonly debug?: boolean;
-  readonly deep?: number;
-  readonly dot?: boolean;
-  readonly expandDirectories?: boolean;
-  readonly followSymbolicLinks?: boolean;
-  readonly globstar?: boolean;
-  readonly ignore?: string | readonly string[];
-  readonly onlyDirectories?: boolean;
-  readonly onlyFiles?: boolean;
+  absolute?: boolean;
+  caseSensitiveMatch?: boolean;
+  cwd?: string;
+  debug?: boolean;
+  deep?: number;
+  dot?: boolean;
+  expandDirectories?: boolean;
+  followSymbolicLinks?: boolean;
+  globstar?: boolean;
+  ignore?: string | readonly string[];
+  onlyDirectories?: boolean;
+  onlyFiles?: boolean;
   /**
    * @deprecated Provide patterns as the first argument instead.
    */
-  readonly patterns?: string | readonly string[];
-  readonly signal?: AbortSignal;
+  patterns?: string | readonly string[];
+  signal?: AbortSignal;
 }
 
 interface InternalProps {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,9 @@
 import { posix } from 'node:path';
 import picomatch, { type PicomatchOptions } from 'picomatch';
 
+// The `Array.isArray` type guard doesn't work for readonly arrays.
+export const isReadonlyArray: (arg: unknown) => arg is readonly unknown[] = Array.isArray;
+
 const isWin = process.platform === 'win32';
 
 // #region PARTIAL MATCHER


### PR DESCRIPTION
`globby` allows passing `readonly string[]` and when switching to `tinyglobby` I noticed I couldn't, so here's a PR to fix that (plus allow all options to be `readonly` as well).