### PR TITLE
dev: outsource types to separate file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import path, { posix } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { type Options as FdirOptions, fdir } from 'fdir';
 import picomatch, { type PicomatchOptions } from 'picomatch';
+import type { GlobOptions, InternalProps } from './types.ts';
 import {
   buildFormat,
   buildRelative,
@@ -13,7 +14,6 @@ import {
   log,
   splitPattern
 } from './utils.ts';
-import type { GlobOptions, InternalProps } from './types.ts';
 
 const PARENT_DIRECTORY = /^(\/?\.\.)+/;
 const ESCAPING_BACKSLASHES = /\\(?=[()[\]{}!*+?@|])/g;
@@ -337,5 +337,5 @@ export function globSync(patternsOrOptions: string | readonly string[] | GlobOpt
   return formatPaths(crawler.sync(), relative);
 }
 
-export type { GlobOptions } from './types.ts'
+export type { GlobOptions } from './types.ts';
 export { convertPathToPattern, escapePath, isDynamicPattern } from './utils.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import nativeFs from 'node:fs';
 import path, { posix } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { type Options as FdirOptions, type FSLike, fdir } from 'fdir';
+import { type Options as FdirOptions, fdir } from 'fdir';
 import picomatch, { type PicomatchOptions } from 'picomatch';
 import {
   buildFormat,
@@ -13,113 +13,11 @@ import {
   log,
   splitPattern
 } from './utils.ts';
+import type { GlobOptions, InternalProps } from './types.ts';
 
 const PARENT_DIRECTORY = /^(\/?\.\.)+/;
 const ESCAPING_BACKSLASHES = /\\(?=[()[\]{}!*+?@|])/g;
 const BACKSLASHES = /\\/g;
-
-export interface GlobOptions {
-  /**
-   * Whether to return absolute paths. Disable to have relative paths.
-   * @default false
-   */
-  absolute?: boolean;
-  /**
-   * Enables support for brace expansion syntax, like `{a,b}` or `{1..9}`.
-   * @default true
-   */
-  braceExpansion?: boolean;
-  /**
-   * Whether to match in case-sensitive mode.
-   * @default true
-   */
-  caseSensitiveMatch?: boolean;
-  /**
-   * The working directory in which to search. Results will be returned relative to this directory, unless
-   * {@link absolute} is set.
-   *
-   * It is important to avoid globbing outside this directory when possible, even with absolute paths enabled,
-   * as doing so can harm performance due to having to recalculate relative paths.
-   * @default process.cwd()
-   */
-  cwd?: string | URL;
-  /**
-   * Logs useful debug information. Meant for development purposes. Logs can change at any time.
-   * @default false
-   */
-  debug?: boolean;
-  /**
-   * Maximum directory depth to crawl.
-   * @default Infinity
-   */
-  deep?: number;
-  /**
-   * Whether to return entries that start with a dot, like `.gitignore` or `.prettierrc`.
-   * @default false
-   */
-  dot?: boolean;
-  /**
-   * Whether to automatically expand directory patterns.
-   *
-   * Important to disable if migrating from [`fast-glob`](https://github.com/mrmlnc/fast-glob).
-   * @default true
-   */
-  expandDirectories?: boolean;
-  /**
-   * Enables support for extglobs, like `+(pattern)`.
-   * @default true
-   */
-  extglob?: boolean;
-  /**
-   * Whether to traverse and include symbolic links. Can slightly affect performance.
-   * @default true
-   */
-  followSymbolicLinks?: boolean;
-  /**
-   * An object that overrides `node:fs` functions.
-   * @default import('node:fs')
-   */
-  fs?: FileSystemAdapter;
-  /**
-   * Enables support for matching nested directories with globstars (`**`).
-   * If `false`, `**` behaves exactly like `*`.
-   * @default true
-   */
-  globstar?: boolean;
-  /**
-   * Glob patterns to exclude from the results.
-   * @default []
-   */
-  ignore?: string | readonly string[];
-  /**
-   * Enable to only return directories.
-   * If `true`, disables {@link onlyFiles}.
-   * @default false
-   */
-  onlyDirectories?: boolean;
-  /**
-   * Enable to only return files.
-   * @default true
-   */
-  onlyFiles?: boolean;
-  /**
-   * @deprecated Provide patterns as the first argument instead.
-   */
-  patterns?: string | readonly string[];
-  /**
-   * An `AbortSignal` to abort crawling the file system.
-   * @default undefined
-   */
-  signal?: AbortSignal;
-}
-
-export type FileSystemAdapter = Partial<FSLike>;
-
-interface InternalProps {
-  root: string;
-  commonPath: string[] | null;
-  depthOffset: number;
-}
 
 function normalizePattern(
   pattern: string,
@@ -439,4 +337,5 @@ export function globSync(patternsOrOptions: string | readonly string[] | GlobOpt
   return formatPaths(crawler.sync(), relative);
 }
 
+export type { GlobOptions } from './types.ts'
 export { convertPathToPattern, escapePath, isDynamicPattern } from './utils.ts';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { FSLike } from "fdir";
+import type { FSLike } from 'fdir';
 
 export type FileSystemAdapter = Partial<FSLike>;
 // can't use `Matcher` from picomatch as it requires a second argument since @types/picomatch v4

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,116 @@
+import type { FSLike } from "fdir";
+
+export type FileSystemAdapter = Partial<FSLike>;
+// can't use `Matcher` from picomatch as it requires a second argument since @types/picomatch v4
+export type PartialMatcher = (test: string) => boolean;
+
+export interface InternalProps {
+  root: string;
+  commonPath: string[] | null;
+  depthOffset: number;
+}
+
+// temporary workaround for https://github.com/rolldown/tsdown/issues/391
+export interface PartialMatcherOptions {
+  dot?: boolean;
+  nobrace?: boolean;
+  nocase?: boolean;
+  noextglob?: boolean;
+  noglobstar?: boolean;
+  posix?: boolean;
+}
+
+export interface GlobOptions {
+  /**
+   * Whether to return absolute paths. Disable to have relative paths.
+   * @default false
+   */
+  absolute?: boolean;
+  /**
+   * Enables support for brace expansion syntax, like `{a,b}` or `{1..9}`.
+   * @default true
+   */
+  braceExpansion?: boolean;
+  /**
+   * Whether to match in case-sensitive mode.
+   * @default true
+   */
+  caseSensitiveMatch?: boolean;
+  /**
+   * The working directory in which to search. Results will be returned relative to this directory, unless
+   * {@link absolute} is set.
+   *
+   * It is important to avoid globbing outside this directory when possible, even with absolute paths enabled,
+   * as doing so can harm performance due to having to recalculate relative paths.
+   * @default process.cwd()
+   */
+  cwd?: string | URL;
+  /**
+   * Logs useful debug information. Meant for development purposes. Logs can change at any time.
+   * @default false
+   */
+  debug?: boolean;
+  /**
+   * Maximum directory depth to crawl.
+   * @default Infinity
+   */
+  deep?: number;
+  /**
+   * Whether to return entries that start with a dot, like `.gitignore` or `.prettierrc`.
+   * @default false
+   */
+  dot?: boolean;
+  /**
+   * Whether to automatically expand directory patterns.
+   *
+   * Important to disable if migrating from [`fast-glob`](https://github.com/mrmlnc/fast-glob).
+   * @default true
+   */
+  expandDirectories?: boolean;
+  /**
+   * Enables support for extglobs, like `+(pattern)`.
+   * @default true
+   */
+  extglob?: boolean;
+  /**
+   * Whether to traverse and include symbolic links. Can slightly affect performance.
+   * @default true
+   */
+  followSymbolicLinks?: boolean;
+  /**
+   * An object that overrides `node:fs` functions.
+   * @default import('node:fs')
+   */
+  fs?: FileSystemAdapter;
+  /**
+   * Enables support for matching nested directories with globstars (`**`).
+   * If `false`, `**` behaves exactly like `*`.
+   * @default true
+   */
+  globstar?: boolean;
+  /**
+   * Glob patterns to exclude from the results.
+   * @default []
+   */
+  ignore?: string | readonly string[];
+  /**
+   * Enable to only return directories.
+   * If `true`, disables {@link onlyFiles}.
+   * @default false
+   */
+  onlyDirectories?: boolean;
+  /**
+   * Enable to only return files.
+   * @default true
+   */
+  onlyFiles?: boolean;
+  /**
+   * @deprecated Provide patterns as the first argument instead.
+   */
+  patterns?: string | readonly string[];
+  /**
+   * An `AbortSignal` to abort crawling the file system.
+   * @default undefined
+   */
+  signal?: AbortSignal;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { posix } from 'node:path';
 import picomatch, { type Matcher } from 'picomatch';
+import type { PartialMatcherOptions, PartialMatcher } from './types.ts';
 
 // The `Array.isArray` type guard doesn't work for readonly arrays.
 export const isReadonlyArray: (arg: unknown) => arg is readonly unknown[] = Array.isArray;
@@ -7,20 +8,6 @@ export const isReadonlyArray: (arg: unknown) => arg is readonly unknown[] = Arra
 const isWin = process.platform === 'win32';
 
 // #region PARTIAL MATCHER
-
-// temporary workaround for https://github.com/rolldown/tsdown/issues/391
-interface PartialMatcherOptions {
-  dot?: boolean;
-  nobrace?: boolean;
-  nocase?: boolean;
-  noextglob?: boolean;
-  noglobstar?: boolean;
-  posix?: boolean;
-}
-
-// can't use `Matcher` from picomatch as it requires a second argument since @types/picomatch v4
-type PartialMatcher = (test: string) => boolean;
-
 const ONLY_PARENT_DIRECTORIES = /^(\/?\.\.)+$/;
 
 // the result of over 4 months of figuring stuff out and a LOT of help

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { posix } from 'node:path';
 import picomatch, { type Matcher } from 'picomatch';
-import type { PartialMatcherOptions, PartialMatcher } from './types.ts';
+import type { PartialMatcher, PartialMatcherOptions } from './types.ts';
 
 // The `Array.isArray` type guard doesn't work for readonly arrays.
 export const isReadonlyArray: (arg: unknown) => arg is readonly unknown[] = Array.isArray;


### PR DESCRIPTION
## Goal

This PR does not change the usage or metrics of this package in any shape or form. Instead, it is to ease maintenance for both the maintainer and new contributors trying to learn the structure of the code. Instead of having local types, we gather all used types in one file as overview.

## Why

Having a clear overview of all used types inside this project helps the understanding of each core data structure. It acts like a short summary of what this project works with and documents it just like normal code.

This PR is a split part of the closed PR #88, which grew too much in scope and changes.