### PR TITLE
feat: add sort support

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -28,7 +28,7 @@ export function buildCrawlerInfo(options: InternalOptions, patterns: readonly st
 
   const format = buildFormat(cwd, root, absolute);
 
-  return { processed, matchOptions, cwd, root, absolute, props, format };
+  return { processed, matchOptions, cwd, root, absolute, props, format, patterns };
 }
 // #endregion buildCrawlerInfo
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { buildCrawler } from './crawler.ts';
-import { getOptions, sortFiles } from './sort.ts';
+import { getOptions } from './options.ts';
+import { sortFiles } from './sort.ts';
 import type { Crawler, GlobInput, GlobOptions, RelativeMapper } from './types.ts';
 import { ensureStringArray, isReadonlyArray } from './utils.ts';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,7 @@
-import nativeFs from 'node:fs';
-import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { buildCrawler } from './crawler.ts';
-import type { Crawler, FileSystemAdapter, GlobInput, GlobOptions, InternalOptions, RelativeMapper } from './types.ts';
-import { BACKSLASHES, ensureStringArray, isReadonlyArray, log } from './utils.ts';
+import { getOptions, sortFiles } from './sort.ts';
+import type { Crawler, GlobInput, GlobOptions, RelativeMapper } from './types.ts';
+import { ensureStringArray, isReadonlyArray } from './utils.ts';
 
 function formatPaths(paths: string[], mapper?: false | RelativeMapper) {
   if (mapper) {
@@ -14,44 +12,10 @@ function formatPaths(paths: string[], mapper?: false | RelativeMapper) {
   return paths;
 }
 
-const fsKeys = ['readdir', 'readdirSync', 'realpath', 'realpathSync', 'stat', 'statSync'];
-
-function normalizeFs(fs?: Record<string, unknown>): FileSystemAdapter | undefined {
-  if (fs && fs !== nativeFs) {
-    for (const key of fsKeys) {
-      fs[key] = (fs[key] ? fs : (nativeFs as Record<string, unknown>))[key];
-    }
-  }
-  return fs;
-}
-
-// Object containing all default options to ensure there is no hidden state difference
-// between false and undefined.
-const defaultOptions: GlobOptions = {
-  caseSensitiveMatch: true,
-  cwd: process.cwd(),
-  debug: !!process.env.TINYGLOBBY_DEBUG,
-  expandDirectories: true,
-  followSymbolicLinks: true,
-  onlyFiles: true
-};
-
-function getOptions(options?: GlobOptions): InternalOptions {
-  const opts = { ...defaultOptions, ...options } as InternalOptions;
-
-  opts.cwd = (opts.cwd instanceof URL ? fileURLToPath(opts.cwd) : resolve(opts.cwd)).replace(BACKSLASHES, '/');
-  // Default value of [] will be inserted here if ignore is undefined
-  opts.ignore = ensureStringArray(opts.ignore);
-  opts.fs = normalizeFs(opts.fs);
-
-  if (opts.debug) {
-    log('globbing with options:', opts);
-  }
-
-  return opts;
-}
-
-function getCrawler(globInput: GlobInput, inputOptions: GlobOptions = {}): [] | [Crawler, false | RelativeMapper] {
+function getCrawler(
+  globInput: GlobInput,
+  inputOptions: GlobOptions = {}
+): [] | [Crawler, false | RelativeMapper, GlobOptions, readonly string[]] {
   if (globInput && inputOptions?.patterns) {
     throw new Error('Cannot pass patterns as both an argument and an option');
   }
@@ -61,7 +25,21 @@ function getCrawler(globInput: GlobInput, inputOptions: GlobOptions = {}): [] | 
   const patterns = ensureStringArray((isModern ? globInput : globInput.patterns) ?? '**/*');
   const options = getOptions(isModern ? inputOptions : globInput);
 
-  return patterns.length > 0 ? buildCrawler(options, patterns) : [];
+  if (patterns.length === 0) {
+    return [];
+  }
+
+  const [crawler, relative] = buildCrawler(options, patterns);
+  return [crawler, relative, options, patterns];
+}
+
+function processResults(
+  paths: string[],
+  relative: false | RelativeMapper,
+  options: GlobOptions,
+  patterns: readonly string[]
+): string[] {
+  return sortFiles(formatPaths(paths, relative), patterns, options);
 }
 
 /**
@@ -74,8 +52,12 @@ export function glob(patterns: string | readonly string[], options?: Omit<GlobOp
  */
 export function glob(options: GlobOptions): Promise<string[]>;
 export async function glob(globInput: GlobInput, options?: GlobOptions): Promise<string[]> {
-  const [crawler, relative] = getCrawler(globInput, options);
-  return crawler ? formatPaths(await crawler.withPromise(), relative) : [];
+  const result = getCrawler(globInput, options);
+  if (result.length === 0) {
+    return [];
+  }
+  const [crawler, relative, opts, patterns] = result;
+  return processResults(await crawler.withPromise(), relative, opts, patterns);
 }
 
 /**
@@ -88,9 +70,14 @@ export function globSync(patterns: string | readonly string[], options?: Omit<Gl
  */
 export function globSync(options: GlobOptions): string[];
 export function globSync(globInput: GlobInput, options?: GlobOptions): string[] {
-  const [crawler, relative] = getCrawler(globInput, options);
-  return crawler ? formatPaths(crawler.sync(), relative) : [];
+  const result = getCrawler(globInput, options);
+  if (result.length === 0) {
+    return [];
+  }
+  const [crawler, relative, opts, patterns] = result;
+  return processResults(crawler.sync(), relative, opts, patterns);
 }
 
+export { compileMatchers, sortFiles, sortFilesByPatternPrecedence } from './sort.ts';
 export type { GlobOptions } from './types.ts';
 export { convertPathToPattern, escapePath, isDynamicPattern } from './utils.ts';

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,42 @@
+import nativeFs from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { FileSystemAdapter, GlobOptions, InternalOptions } from './types.ts';
+import { BACKSLASHES, ensureStringArray, log } from './utils.ts';
+
+const fsKeys = ['readdir', 'readdirSync', 'realpath', 'realpathSync', 'stat', 'statSync'];
+
+function normalizeFs(fs?: Record<string, unknown>): FileSystemAdapter | undefined {
+  if (fs && fs !== nativeFs) {
+    for (const key of fsKeys) {
+      fs[key] = (fs[key] ? fs : (nativeFs as Record<string, unknown>))[key];
+    }
+  }
+  return fs;
+}
+
+// Object containing all default options to ensure there is no hidden state difference
+// between false and undefined.
+const defaultOptions: GlobOptions = {
+  caseSensitiveMatch: true,
+  cwd: process.cwd(),
+  debug: !!process.env.TINYGLOBBY_DEBUG,
+  expandDirectories: true,
+  followSymbolicLinks: true,
+  onlyFiles: true
+};
+
+export function getOptions(options?: GlobOptions): InternalOptions {
+  const opts = { ...defaultOptions, ...options } as InternalOptions;
+
+  opts.cwd = (opts.cwd instanceof URL ? fileURLToPath(opts.cwd) : resolve(opts.cwd)).replace(BACKSLASHES, '/');
+  // Default value of [] will be inserted here if ignore is undefined
+  opts.ignore = ensureStringArray(opts.ignore);
+  opts.fs = normalizeFs(opts.fs);
+
+  if (opts.debug) {
+    log('globbing with options:', opts);
+  }
+
+  return opts;
+}

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,47 +1,8 @@
-import nativeFs from 'node:fs';
-import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import picomatch, { type PicomatchOptions } from 'picomatch';
+import { getOptions } from './options.ts';
 import processPatterns from './patterns.ts';
-import type { FileSystemAdapter, GlobOptions, InternalOptions, InternalProps } from './types.ts';
+import type { GlobOptions, InternalProps } from './types.ts';
 import { BACKSLASHES, buildFormat, ensureStringArray, log } from './utils.ts';
-
-const fsKeys = ['readdir', 'readdirSync', 'realpath', 'realpathSync', 'stat', 'statSync'];
-
-function normalizeFs(fs?: Record<string, unknown>): FileSystemAdapter | undefined {
-  if (fs && fs !== nativeFs) {
-    for (const key of fsKeys) {
-      fs[key] = (fs[key] ? fs : (nativeFs as Record<string, unknown>))[key];
-    }
-  }
-  return fs;
-}
-
-// Object containing all default options to ensure there is no hidden state difference
-// between false and undefined.
-const defaultOptions: GlobOptions = {
-  caseSensitiveMatch: true,
-  cwd: process.cwd(),
-  debug: !!process.env.TINYGLOBBY_DEBUG,
-  expandDirectories: true,
-  followSymbolicLinks: true,
-  onlyFiles: true
-};
-
-export function getOptions(options?: GlobOptions): InternalOptions {
-  const opts = { ...defaultOptions, ...options } as InternalOptions;
-
-  opts.cwd = (opts.cwd instanceof URL ? fileURLToPath(opts.cwd) : resolve(opts.cwd)).replace(BACKSLASHES, '/');
-  // Default value of [] will be inserted here if ignore is undefined
-  opts.ignore = ensureStringArray(opts.ignore);
-  opts.fs = normalizeFs(opts.fs);
-
-  if (opts.debug) {
-    log('globbing with options:', opts);
-  }
-
-  return opts;
-}
 
 /**
  * Compiles glob patterns into matcher functions using the exact same logic as `glob` and `globSync`.

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -135,6 +135,8 @@ const sortDesc = (a: string, b: string) => b.localeCompare(a);
  */
 export function sortFiles(files: string[], patterns: string | readonly string[], options?: GlobOptions): string[] {
   switch (true) {
+    case typeof options?.sort === 'function':
+      return files.sort(options.sort);
     case options?.sort === 'asc':
       return files.sort(sortAsc);
     case options?.sort === 'desc':

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -26,7 +26,7 @@ import { BACKSLASHES, buildFormat, ensureStringArray, log } from './utils.ts';
  * function would continue to work without any changes.
  *
  * @param patterns The glob pattern(s).
- * @param options The options object if the first argument is the pattern(s).
+ * @param options The options.
  * @yields A readonly tuple `[glob, matcher]` containing:
  * - `glob`: The normalized and processed glob pattern.
  * - `matcher`: The pre-compiled matcher function for that specific pattern.
@@ -89,7 +89,7 @@ import { BACKSLASHES, buildFormat, ensureStringArray, log } from './utils.ts';
  */
 export function* compileMatchers(
   patterns: string | readonly string[],
-  options?: GlobOptions
+  options?: Omit<GlobOptions, 'patterns'>
 ): Generator<readonly [glob: string, match: (path: string) => boolean], undefined, void> {
   // defaulting to ['**/*'] is tinyglobby exclusive behavior, deprecated
   const usePatterns = ensureStringArray(patterns);
@@ -130,10 +130,14 @@ const sortDesc = (a: string, b: string) => b.localeCompare(a);
  * Sort files from a glob scan.
  * @param files The files from a glob scan.
  * @param patterns The glob pattern(s).
- * @param options The options object if the first argument is the pattern(s).
+ * @param options The options.
  * @returns The files from a glob scan sorted.
  */
-export function sortFiles(files: string[], patterns: string | readonly string[], options?: GlobOptions): string[] {
+export function sortFiles(
+  files: string[],
+  patterns: string | readonly string[],
+  options?: Omit<GlobOptions, 'patterns'>
+): string[] {
   switch (true) {
     case typeof options?.sort === 'function':
       return files.sort(options.sort);
@@ -154,13 +158,13 @@ export function sortFiles(files: string[], patterns: string | readonly string[],
  * Sort files from a glob scan.
  * @param files The files from a glob scan.
  * @param patterns The glob pattern(s).
- * @param options The options object if the first argument is the pattern(s).
+ * @param options The options.
  * @yields The files from a glob scan sorted.
  */
 export function* sortFilesByPatternPrecedence(
   files: string[],
   patterns: string | readonly string[],
-  options?: GlobOptions
+  options?: Omit<GlobOptions, 'patterns'>
 ): Generator<string, undefined, void> {
   const sort = options?.sort ?? 'pattern';
   if (sort !== 'pattern' && sort !== 'pattern-asc' && sort !== 'pattern-desc') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { FSLike, PathsOutput, ResultCallback } from 'fdir';
+import type { PicomatchOptions } from 'picomatch';
 
 export type FileSystemAdapter = Partial<FSLike>;
 // can't use `Matcher` from picomatch as it requires a second argument since @types/picomatch v4
@@ -36,6 +37,18 @@ export interface ProcessedPatterns {
   match: string[];
   ignore: string[];
 }
+
+export interface CrawlerInfo {
+  processed: ProcessedPatterns;
+  matchOptions: PicomatchOptions;
+  cwd: string;
+  root: string;
+  absolute?: boolean;
+  props: InternalProps;
+  format: (p: string, isDir: boolean) => string;
+}
+
+export type Sort = 'asc' | 'desc' | 'pattern' | 'pattern-asc' | 'pattern-desc' | ((a: string, b: string) => number);
 
 export interface GlobOptions {
   /**
@@ -140,7 +153,7 @@ export interface GlobOptions {
    * - `(a: string, b: string) => number`: A custom sort function.
    * @default undefined
    */
-  sort?: 'asc' | 'desc' | 'pattern' | 'pattern-asc' | 'pattern-desc' | ((a: string, b: string) => number);
+  sort?: Sort;
 }
 
 export type InternalOptions = Pick<

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export interface CrawlerInfo {
   root: string;
   absolute?: boolean;
   props: InternalProps;
+  patterns: readonly string[];
   format: (p: string, isDir: boolean) => string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,9 +137,10 @@ export interface GlobOptions {
    * - `pattern`: Sorts the results by pattern precedence.
    * - `pattern-asc`: Sorts the results by pattern precedence and then ascending.
    * - `pattern-desc`: Sorts the results by pattern precedence and then descending.
+   * - `(a: string, b: string) => number`: A custom sort function.
    * @default undefined
    */
-  sort?: 'asc' | 'desc' | 'pattern' | 'pattern-asc' | 'pattern-desc';
+  sort?: 'asc' | 'desc' | 'pattern' | 'pattern-asc' | 'pattern-desc' | ((a: string, b: string) => number);
 }
 
 export type InternalOptions = Pick<

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,16 @@ export interface GlobOptions {
    * @default undefined
    */
   signal?: AbortSignal;
+  /**
+   * Sort the results.
+   * - `asc`: Sorts the results in ascending order.
+   * - `desc`: Sorts the results in descending order.
+   * - `pattern`: Sorts the results by pattern precedence.
+   * - `pattern-asc`: Sorts the results by pattern precedence and then ascending.
+   * - `pattern-desc`: Sorts the results by pattern precedence and then descending.
+   * @default undefined
+   */
+  sort?: 'asc' | 'desc' | 'pattern' | 'pattern-asc' | 'pattern-desc';
 }
 
 export type InternalOptions = Pick<

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -498,3 +498,32 @@ test('relative self + normal pattern', () => {
   });
   assert.deepEqual(files.sort(), ['.', 'a/a.txt']);
 });
+
+test('sort asc', async () => {
+  const files = await glob('**/*', { cwd, sort: 'asc' });
+  assert.deepEqual(files, ['a/a.txt', 'a/b.txt', 'b/a.txt', 'b/b.txt']);
+});
+
+test('sort desc', async () => {
+  const files = await glob('**/*', { cwd, sort: 'desc' });
+  assert.deepEqual(files, ['b/b.txt', 'b/a.txt', 'a/b.txt', 'a/a.txt']);
+});
+
+test('sort pattern', async () => {
+  const files = await glob(['b/*', 'a/*'], { cwd, sort: 'pattern' });
+  assert.equal(files.length, 4);
+  assert.ok(files[0].startsWith('b/'));
+  assert.ok(files[1].startsWith('b/'));
+  assert.ok(files[2].startsWith('a/'));
+  assert.ok(files[3].startsWith('a/'));
+});
+
+test('sort pattern-asc', async () => {
+  const files = await glob(['b/*', 'a/*'], { cwd, sort: 'pattern-asc' });
+  assert.deepEqual(files, ['b/a.txt', 'b/b.txt', 'a/a.txt', 'a/b.txt']);
+});
+
+test('sort pattern-desc', async () => {
+  const files = await glob(['b/*', 'a/*'], { cwd, sort: 'pattern-desc' });
+  assert.deepEqual(files, ['b/b.txt', 'b/a.txt', 'a/b.txt', 'a/a.txt']);
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -527,3 +527,8 @@ test('sort pattern-desc', async () => {
   const files = await glob(['b/*', 'a/*'], { cwd, sort: 'pattern-desc' });
   assert.deepEqual(files, ['b/b.txt', 'b/a.txt', 'a/b.txt', 'a/a.txt']);
 });
+
+test('sort custom', async () => {
+  const files = await glob('**/*', { cwd, sort: (a, b) => a.localeCompare(b) });
+  assert.deepEqual(files, ['a/a.txt', 'a/b.txt', 'b/a.txt', 'b/b.txt']);
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -532,3 +532,18 @@ test('sort custom', async () => {
   const files = await glob('**/*', { cwd, sort: (a, b) => a.localeCompare(b) });
   assert.deepEqual(files, ['a/a.txt', 'a/b.txt', 'b/a.txt', 'b/b.txt']);
 });
+
+test('sort asc with multiple patterns', async () => {
+  const files = await glob(['a/*', 'b/*'], { cwd, sort: 'asc' });
+  assert.deepEqual(files, ['a/a.txt', 'a/b.txt', 'b/a.txt', 'b/b.txt']);
+});
+
+test('sort desc with multiple patterns', async () => {
+  const files = await glob(['a/*', 'b/*'], { cwd, sort: 'desc' });
+  assert.deepEqual(files, ['b/b.txt', 'b/a.txt', 'a/b.txt', 'a/a.txt']);
+});
+
+test('sort custom with multiple patterns', async () => {
+  const files = await glob(['a/*', 'b/*'], { cwd, sort: (a, b) => a.localeCompare(b) });
+  assert.deepEqual(files, ['a/a.txt', 'a/b.txt', 'b/a.txt', 'b/b.txt']);
+});

--- a/test/sort.test.ts
+++ b/test/sort.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { after, test } from 'node:test';
+import { createFixture } from 'fs-fixture';
+import { sortFiles, sortFilesByPatternPrecedence } from '../src/sort.ts';
+import type { GlobInput } from '../src/types.ts';
+
+const fixture = await createFixture({
+  common: {
+    'Button.js': 'a',
+    'Card.js': 'a'
+  },
+  overrides: {
+    'Button.js': 'b'
+  }
+});
+
+const cwd = fixture.path;
+const escapedCwd = cwd.replaceAll('\\', '/');
+const options = {
+  cwd,
+  absolute: true,
+  onlyFiles: true,
+  expandDirectories: false
+} satisfies GlobInput;
+const patterns = [
+  `overrides/**/*.js`, // Highest priority
+  'common/**/*.js' // Normal priority
+];
+
+after(() => fixture.rm());
+
+test('sort files without sort', () => {
+  const files = [`${escapedCwd}/overrides/Button.js`, `${escapedCwd}/common/Card.js`, `${escapedCwd}/common/Button.js`];
+  assert.deepEqual(sortFiles(files, patterns, options), [
+    `${escapedCwd}/overrides/Button.js`,
+    `${escapedCwd}/common/Card.js`,
+    `${escapedCwd}/common/Button.js`
+  ]);
+});
+test('sort files ascending', () => {
+  const files = [`${escapedCwd}/overrides/Button.js`, `${escapedCwd}/common/Card.js`, `${escapedCwd}/common/Button.js`];
+  const useOptions = { ...options, sort: 'asc' } satisfies GlobInput;
+  assert.deepEqual(sortFiles(files, patterns, useOptions), [
+    `${escapedCwd}/common/Button.js`,
+    `${escapedCwd}/common/Card.js`,
+    `${escapedCwd}/overrides/Button.js`
+  ]);
+});
+test('sort files descending', () => {
+  const files = [`${escapedCwd}/common/Button.js`, `${escapedCwd}/common/Card.js`, `${escapedCwd}/overrides/Button.js`];
+  const useOptions = { ...options, sort: 'desc' } satisfies GlobInput;
+  assert.deepEqual(sortFiles(files, patterns, useOptions), [
+    `${escapedCwd}/overrides/Button.js`,
+    `${escapedCwd}/common/Card.js`,
+    `${escapedCwd}/common/Button.js`
+  ]);
+});
+test('sort files by precedence without sort', () => {
+  const files = [`${escapedCwd}/common/Button.js`, `${escapedCwd}/common/Card.js`, `${escapedCwd}/overrides/Button.js`];
+  assert.deepEqual(
+    [...sortFilesByPatternPrecedence(files, patterns, options)],
+    [`${escapedCwd}/overrides/Button.js`, `${escapedCwd}/common/Button.js`, `${escapedCwd}/common/Card.js`]
+  );
+});
+test('sort files by precedence with sort ascending (no sort)', () => {
+  const files = [`${escapedCwd}/common/Button.js`, `${escapedCwd}/common/Card.js`, `${escapedCwd}/overrides/Button.js`];
+  const useOptions = { ...options, sort: 'asc' } satisfies GlobInput;
+  assert.deepEqual(
+    [...sortFilesByPatternPrecedence(files, patterns, useOptions)],
+    [`${escapedCwd}/common/Button.js`, `${escapedCwd}/common/Card.js`, `${escapedCwd}/overrides/Button.js`]
+  );
+});
+test('sort files by precedence', () => {
+  const files = [`${escapedCwd}/common/Button.js`, `${escapedCwd}/common/Card.js`, `${escapedCwd}/overrides/Button.js`];
+  const useOptions = { ...options, sort: 'pattern' } satisfies GlobInput;
+  assert.deepEqual(
+    [...sortFilesByPatternPrecedence(files, patterns, useOptions)],
+    [`${escapedCwd}/overrides/Button.js`, `${escapedCwd}/common/Button.js`, `${escapedCwd}/common/Card.js`]
+  );
+});
+test('sort files by precedence with no sort', () => {
+  const files = [`${escapedCwd}/common/Button.js`, `${escapedCwd}/common/Card.js`, `${escapedCwd}/overrides/Button.js`];
+  assert.deepEqual(
+    [...sortFilesByPatternPrecedence(files, patterns, options)],
+    [`${escapedCwd}/overrides/Button.js`, `${escapedCwd}/common/Button.js`, `${escapedCwd}/common/Card.js`]
+  );
+});
+test('sort files by precedence ascending', () => {
+  const files = [`${escapedCwd}/common/Card.js`, `${escapedCwd}/common/Button.js`, `${escapedCwd}/overrides/Button.js`];
+  const result = [
+    `${escapedCwd}/overrides/Button.js`,
+    `${escapedCwd}/common/Button.js`,
+    `${escapedCwd}/common/Card.js`
+  ];
+  const useOptions = { ...options, sort: 'pattern-asc' } satisfies GlobInput;
+  assert.deepEqual([...sortFilesByPatternPrecedence(files, patterns, useOptions)], result);
+  assert.deepEqual(sortFiles(files, patterns, useOptions), result);
+});
+test('sort files by precedence descending', () => {
+  const files = [`${escapedCwd}/common/Button.js`, `${escapedCwd}/common/Card.js`, `${escapedCwd}/overrides/Button.js`];
+  const result = [
+    `${escapedCwd}/overrides/Button.js`,
+    `${escapedCwd}/common/Card.js`,
+    `${escapedCwd}/common/Button.js`
+  ];
+  const useOptions = { ...options, sort: 'pattern-desc', debug: true } satisfies GlobInput;
+  assert.deepEqual([...sortFilesByPatternPrecedence(files, patterns, useOptions)], result);
+  assert.deepEqual(sortFiles(files, patterns, useOptions), result);
+});


### PR DESCRIPTION
## Description

This PR adds built-in sorting support to `glob` and `globSync` to ensure predictable results. This is crucial for tools like `unplugin-vue-components` (and maybe at `unimport`, and `unplugin-auto-import`), where declaration overwrites and `.d.ts` generation need to be deterministic.

It introduces a new `sort` option with the following modes:
- `'asc'`: Sorts results in ascending order (alphabetical).
- `'desc'`: Sorts results in descending order.
- `'pattern'`: Sorts results based on the order of the provided patterns (precedence).
- `'pattern-asc'`: Sorts by pattern precedence, then ascending within matches of the same pattern.
- `'pattern-desc'`: Sorts by pattern precedence, then descending within matches of the same pattern.
- `Function`: A custom comparison function `(a: string, b: string) => number`.

## Changes

- **Refactor**: extracted `getOptions` from `index.ts` to a new `options.ts` module (reusing it at `crawler.ts` and `sort.ts`)
- **Refactor**: extracted patterns logic at `crawler.ts` to `buildCrawlerInfo` function (reusing it at `index.ts` and `sort.ts`)
- **Feat**: Added `sort` option to `GlobOptions`.
- **Feat**: Added `compileMatchers`, `sortFiles` and `sortFilesByPatternPrecedence` exported utilities.
- **Refactor**: Renamed `compileGlobs` to `compileMatchers` and moved logic to `src/sort.ts` from original PR #168.

resolves #166
supersedes #168