### PR TITLE
Avoid compiling ignore patterns twice

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -26,7 +26,7 @@ export function buildCrawler(options: InternalOptions, patterns: readonly string
     posix: true
   } satisfies PicomatchOptions;
 
-  const matcher = picomatch(processed.match, { ...matchOptions, ignore: processed.ignore });
+  const matcher = picomatch(processed.match, matchOptions);
   const ignore = picomatch(processed.ignore, matchOptions);
   const partialMatcher = getPartialMatcher(processed.match, matchOptions);
 
@@ -49,7 +49,7 @@ export function buildCrawler(options: InternalOptions, patterns: readonly string
       debug
         ? (p, isDirectory) => {
             const path = format(p, isDirectory);
-            const matches = matcher(path);
+            const matches = matcher(path) && !ignore(path);
 
             if (matches) {
               log(`matched ${path}`);
@@ -57,7 +57,10 @@ export function buildCrawler(options: InternalOptions, patterns: readonly string
 
             return matches;
           }
-        : (p, isDirectory) => matcher(format(p, isDirectory))
+        : (p, isDirectory) => {
+            const path = format(p, isDirectory);
+            return matcher(path) && !ignore(path);
+          }
     ],
     exclude: debug
       ? (_, p) => {


### PR DESCRIPTION
The ignore patterns were compiled both via picomatch's ignore option and as a standalone matcher. This PR makes it compile once, and apply manually in filter only.

Coming from https://github.com/webpro-nl/knip/pull/1462#issuecomment-3798356914. The change in this PR would make globbing go from >700ms to <320ms in that particular setup, because there are lots of `.gitignore` files resulting in lots of `ignore` patterns passed in to `tinyglobby#globSync`

Here's a script to benchmark the difference:

```ts
import { globSync } from './dist/index.mjs';
const ignore = [
  '**/node_modules/**',
  '**/.git/**',
  '**/dist/**',
  '**/build/**',
  '**/coverage/**',
  ...Array.from({ length: 35 }, (_, i) => `**/ignored${i}/**`)
];
const patterns = ['**/*.ts', '**/*.js'];
const cwd = process.cwd();
globSync(patterns, { cwd, ignore }); // Warm up
const iterations = 500;
const start = performance.now();
for (let i = 0; i < iterations; i++) {
  globSync(patterns, { cwd, ignore, expandDirectories: false });
}
const elapsed = performance.now() - start;
console.log(`Total: ${elapsed.toFixed(0)}ms`);
console.log(`Avg: ${(elapsed / iterations).toFixed(2)}ms`);
```

This should show >40% improvement in time spent compared with main.

Let me know if you need anything else or how I can help with improve/benchmark this. Figured tests passing is enough for general QA?