### PR TITLE
fix: handle drive-relative paths on windows

### DIFF
--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -1,6 +1,6 @@
 import { isAbsolute, posix } from 'node:path';
 import type { InternalOptions, InternalProps, ProcessedPatterns } from './types.ts';
-import { escapePath, ensureNonDriveRelativePath, isDynamicPattern, splitPattern } from './utils.ts';
+import { ensureNonDriveRelativePath, escapePath, isDynamicPattern, splitPattern } from './utils.ts';
 
 const PARENT_DIRECTORY = /^(\/?\.\.)+/;
 const ESCAPING_BACKSLASHES = /\\(?=[()[\]{}!*+?@|])/g;

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -1,6 +1,6 @@
 import { isAbsolute, posix } from 'node:path';
 import type { InternalOptions, InternalProps, ProcessedPatterns } from './types.ts';
-import { escapePath, isDynamicPattern, splitPattern } from './utils.ts';
+import { escapePath, ensureNonDriveRelativePath, isDynamicPattern, splitPattern } from './utils.ts';
 
 const PARENT_DIRECTORY = /^(\/?\.\.)+/;
 const ESCAPING_BACKSLASHES = /\\(?=[()[\]{}!*+?@|])/g;
@@ -39,7 +39,7 @@ function normalizePattern(pattern: string, opts: InternalOptions, props: Interna
     const potentialRoot = posix.join(cwd, parentDir.slice(i * 3));
     // windows can make the potential root something like `../C:`, we don't want that
     if (potentialRoot[0] !== '.' && props.root.length > potentialRoot.length) {
-      props.root = potentialRoot;
+      props.root = ensureNonDriveRelativePath(potentialRoot);
       props.depthOffset = -n + i;
     }
   }
@@ -68,7 +68,7 @@ function normalizePattern(pattern: string, opts: InternalOptions, props: Interna
     props.depthOffset = newCommonPath.length;
     props.commonPath = newCommonPath;
 
-    props.root = newCommonPath.length > 0 ? posix.join(cwd, ...newCommonPath) : cwd;
+    props.root = ensureNonDriveRelativePath(newCommonPath.length > 0 ? posix.join(cwd, ...newCommonPath) : cwd);
   }
 
   return result;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,9 @@ import type { PartialMatcher, PartialMatcherOptions } from './types.ts';
 // The `Array.isArray` type guard doesn't work for readonly arrays.
 export const isReadonlyArray: (arg: unknown) => arg is readonly unknown[] = Array.isArray;
 export const BACKSLASHES: RegExp = /\\/g;
+// We only guard bare drive roots like `L:`; longer drive-relative strings like
+// `L:foo` don't come out of our normalization path.
+const DRIVE_RELATIVE_PATH: RegExp = /^[A-Za-z]:$/;
 
 const isWin = process.platform === 'win32';
 
@@ -126,6 +129,11 @@ export function buildRelative(cwd: string, root: string): (p: string) => string 
     const result = posix.relative(cwd, `${root}/${p}`);
     return p[p.length - 1] === '/' && result !== '' ? `${result}/` : result || '.';
   };
+}
+
+export function ensureNonDriveRelativePath(path: string): string {
+  // On Windows, drive-relative paths like `L:` resolve against cwd, which is undesirable. See #196.
+  return path.replace(DRIVE_RELATIVE_PATH, match => `${match}/`);
 }
 // #endregion
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,13 +1,9 @@
 import assert from 'node:assert/strict';
-import { randomUUID } from 'node:crypto';
 import { readdir } from 'node:fs';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { after, test } from 'node:test';
 import { createFixture } from 'fs-fixture';
 import { glob, globSync } from '../src/index.ts';
-
-const winTest = process.platform === 'win32' ? test : test.skip;
 
 // object properties are file names and values are file contents
 const fixture = await createFixture({
@@ -91,27 +87,6 @@ test('absolutely crawl root', async () => {
 test('cwd as URL', async () => {
   const files = await glob('a/a.txt', { cwd: new URL(`file://${escapedCwd}`) });
   assert.deepEqual(files.sort(), ['a/a.txt']);
-});
-
-// This repro depends on Windows drive semantics, and CI runs Windows tests, so we can cover it directly.
-winTest('drive-relative roots keep absolute matches on Windows', async () => {
-  const id = randomUUID();
-  const root = `C:/tinyglobby-root-${id}`;
-  const cwdRoot = `C:/tinyglobby-cwd-${id}/a/b/c/d/e`;
-
-  await mkdir(root, { recursive: true });
-  await mkdir(cwdRoot, { recursive: true });
-  await writeFile(`${root}/a.py`, '');
-  await writeFile(`${root}/b.py`, '');
-  await writeFile(`${root}/c.py`, '');
-
-  try {
-    const files = await glob(`${root}/*.py`, { cwd: cwdRoot, absolute: true });
-    assert.deepEqual(files.sort(), [`${root}/a.py`, `${root}/b.py`, `${root}/c.py`]);
-  } finally {
-    await rm(`C:/tinyglobby-root-${id}`, { recursive: true, force: true });
-    await rm(`C:/tinyglobby-cwd-${id}`, { recursive: true, force: true });
-  }
 });
 
 test('fs option', async t => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,9 +1,13 @@
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import { readdir } from 'node:fs';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { after, test } from 'node:test';
 import { createFixture } from 'fs-fixture';
 import { glob, globSync } from '../src/index.ts';
+
+const winTest = process.platform === 'win32' ? test : test.skip;
 
 // object properties are file names and values are file contents
 const fixture = await createFixture({
@@ -87,6 +91,27 @@ test('absolutely crawl root', async () => {
 test('cwd as URL', async () => {
   const files = await glob('a/a.txt', { cwd: new URL(`file://${escapedCwd}`) });
   assert.deepEqual(files.sort(), ['a/a.txt']);
+});
+
+// This repro depends on Windows drive semantics, and CI runs Windows tests, so we can cover it directly.
+winTest('drive-relative roots keep absolute matches on Windows', async () => {
+  const id = randomUUID();
+  const root = `C:/tinyglobby-root-${id}`;
+  const cwdRoot = `C:/tinyglobby-cwd-${id}/a/b/c/d/e`;
+
+  await mkdir(root, { recursive: true });
+  await mkdir(cwdRoot, { recursive: true });
+  await writeFile(`${root}/a.py`, '');
+  await writeFile(`${root}/b.py`, '');
+  await writeFile(`${root}/c.py`, '');
+
+  try {
+    const files = await glob(`${root}/*.py`, { cwd: cwdRoot, absolute: true });
+    assert.deepEqual(files.sort(), [`${root}/a.py`, `${root}/b.py`, `${root}/c.py`]);
+  } finally {
+    await rm(`C:/tinyglobby-root-${id}`, { recursive: true, force: true });
+    await rm(`C:/tinyglobby-cwd-${id}`, { recursive: true, force: true });
+  }
 });
 
 test('fs option', async t => {

--- a/test/utils/ensureNonDriveRelativePath.test.ts
+++ b/test/utils/ensureNonDriveRelativePath.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { ensureNonDriveRelativePath } from '../../src/utils.ts';
+
+describe('ensureNonDriveRelativePath', () => {
+  test('keeps normal absolute paths unchanged', () => {
+    assert.equal(ensureNonDriveRelativePath('L:/test1/a'), 'L:/test1/a');
+  });
+
+  test('already-absolute paths should be unchanged', () => {
+    assert.equal(ensureNonDriveRelativePath('L:/'), 'L:/');
+  });
+
+  test("Non-Windows paths shouldn't be affected", () => {
+    assert.equal(ensureNonDriveRelativePath('/test1/a'), '/test1/a');
+  });
+
+  test('converts drive-relative roots to drive-absolute paths', () => {
+    assert.equal(ensureNonDriveRelativePath('L:'), 'L:/');
+  });
+});

--- a/test/utils/ensureNonDriveRelativePath.test.ts
+++ b/test/utils/ensureNonDriveRelativePath.test.ts
@@ -11,7 +11,7 @@ describe('ensureNonDriveRelativePath', () => {
     assert.equal(ensureNonDriveRelativePath('L:/'), 'L:/');
   });
 
-  test("Non-Windows paths shouldn't be affected", () => {
+  test("non-Windows paths shouldn't be affected", () => {
     assert.equal(ensureNonDriveRelativePath('/test1/a'), '/test1/a');
   });
 


### PR DESCRIPTION
Resolves https://github.com/SuperchupuDev/tinyglobby/issues/196

Just when I thought I learned all Windows quirks, I've found one more...

Turned out, on Windows `L:` is not the same thing as `L:\`. It's called drive-relative path (see https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#apply-the-current-directory) and `L:` ends up being replace with cwd.

```js
import { resolve } from "node:path";

// cwd: L:\oblivion\tinyglobby
console.log("cwd:", resolve("."));
// resolve("L:"): L:\oblivion\tinyglobby
console.log('resolve("L:"):', resolve("L:"));
// resolve("L:/"): L:\
console.log('resolve("L:/"):', resolve("L:/"));
// resolve("L:\\"): L:\
console.log('resolve("L:\\"):', resolve("L:\\"));
```

In my case I've stumbled upon, I had `L:\test1\repro.js` running `L:\test\*.py` pattern while being in `L:\test1` as cwd.
So naturally, `glob` have found a common root to start from - `L:`, but when `absolute` is set to `true`.


The call chain goes like this

`glob` calls `.withPromise`

https://github.com/SuperchupuDev/tinyglobby/blob/577920259c91f5603fab3dbfa599a83bbb14a27a/src/index.ts#L75

Which constructs a `Walker`.

https://github.com/thecodrr/fdir/blob/790c182eb54809ea7bc14f1bcb40acce89506bb4/src/api/async.ts#L21

Which calls `normalizePath`.

https://github.com/thecodrr/fdir/blob/790c182eb54809ea7bc14f1bcb40acce89506bb4/src/api/walker.ts#L40

Which calls `resolve` on `root`, but only in case if `resolvePaths` is set.

https://github.com/thecodrr/fdir/blob/790c182eb54809ea7bc14f1bcb40acce89506bb4/src/utils.ts#L33-L39

Which is set, when constructing options for a crawler, from `absolute` option:

https://github.com/SuperchupuDev/tinyglobby/blob/577920259c91f5603fab3dbfa599a83bbb14a27a/src/crawler.ts#L74

Since `L:` root comes from `normalizePattern` call, I've added a check to ensure it appends `/` in case it's drive-relative path to make it just abs path at drive root and added a test.

I've created a workflow to reproduce the issue before and after the fix https://github.com/Andrej730/tinyglobby/actions/runs/24131845264/job/70410134306

<img width="682" height="427" alt="image" src="https://github.com/user-attachments/assets/880d74f3-f123-4e14-a2cd-63aab18c633e" />


@SuperchupuDev can you please take a look?
