### PR TITLE
fix: preserve truthy defaults when glob options are passed as undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,10 @@ function formatPaths(paths: string[], mapper?: false | RelativeMapper) {
 }
 
 // Object containing all default options to ensure there is no hidden state difference
-// between false and undefined.
+// between false and undefined. cwd is intentionally excluded as process.cwd() must be
+// evaluated at call time, not at module load time.
 const defaultOptions: GlobOptions = {
   caseSensitiveMatch: true,
-  cwd: process.cwd(),
   debug: !!process.env.TINYGLOBBY_DEBUG,
   expandDirectories: true,
   followSymbolicLinks: true,
@@ -33,7 +33,9 @@ function getOptions(options?: GlobOptions): InternalOptions {
     }
   }
 
-  opts.cwd = (opts.cwd instanceof URL ? fileURLToPath(opts.cwd) : resolve(opts.cwd)).replace(BACKSLASHES, '/');
+  const resolvedCwd = opts.cwd instanceof URL ? fileURLToPath(opts.cwd) : resolve(opts.cwd ?? process.cwd());
+  opts.cwd = resolvedCwd.replace(BACKSLASHES, '/');
+
   // Default value of [] will be inserted here if ignore is undefined
   opts.ignore = ensureStringArray(opts.ignore);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ function getOptions(options?: GlobOptions): InternalOptions {
     }
   }
 
-  const resolvedCwd = opts.cwd instanceof URL ? fileURLToPath(opts.cwd) : resolve(opts.cwd ?? process.cwd());
+  const resolvedCwd = opts.cwd instanceof URL ? fileURLToPath(opts.cwd) : resolve(opts.cwd || process.cwd());
   opts.cwd = resolvedCwd.replace(BACKSLASHES, '/');
 
   // Default value of [] will be inserted here if ignore is undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,13 @@ const defaultOptions: GlobOptions = {
 };
 
 function getOptions(options?: GlobOptions): InternalOptions {
-  const opts = { ...defaultOptions, ...options } as InternalOptions;
+  const opts = Object.assign({}, options) as InternalOptions;
+  for (const key in defaultOptions) {
+    if (opts[key as keyof GlobOptions] === undefined) {
+      Object.assign(opts, { [key]: defaultOptions[key as keyof GlobOptions] });
+    }
+  }
+
 
   opts.cwd = (opts.cwd instanceof URL ? fileURLToPath(opts.cwd) : resolve(opts.cwd)).replace(BACKSLASHES, '/');
   // Default value of [] will be inserted here if ignore is undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,6 @@ function getOptions(options?: GlobOptions): InternalOptions {
     }
   }
 
-
   opts.cwd = (opts.cwd instanceof URL ? fileURLToPath(opts.cwd) : resolve(opts.cwd)).replace(BACKSLASHES, '/');
   // Default value of [] will be inserted here if ignore is undefined
   opts.ignore = ensureStringArray(opts.ignore);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -304,6 +304,17 @@ test('common path prefix is respected across multiple patterns', async () => {
   assert.deepEqual(files.sort(), ['a/a.txt', 'a/b.txt']);
 });
 
+test('cwd defaults to process.cwd() evaluated at call time, not import time', async () => {
+  const importTimeCwd = process.cwd();
+  try {
+    process.chdir(cwd); // cwd !== importTimeCwd (fixture is in a temp dir)
+    const files = await glob('a/*.txt'); // no cwd passed - must use call-time process.cwd()
+    assert.deepEqual(files.sort(), ['a/a.txt', 'a/b.txt']);
+  } finally {
+    process.chdir(importTimeCwd);
+  }
+});
+
 test('explicit undefined options fall back to defaults', async () => {
   // cwd: undefined should not throw
   await assert.doesNotReject(() => glob('*', { cwd: undefined }));

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -304,15 +304,10 @@ test('common path prefix is respected across multiple patterns', async () => {
   assert.deepEqual(files.sort(), ['a/a.txt', 'a/b.txt']);
 });
 
-test('cwd defaults to process.cwd() evaluated at call time, not import time', async () => {
-  const importTimeCwd = process.cwd();
-  try {
-    process.chdir(cwd); // cwd !== importTimeCwd (fixture is in a temp dir)
-    const files = await glob('a/*.txt'); // no cwd passed - must use call-time process.cwd()
-    assert.deepEqual(files.sort(), ['a/a.txt', 'a/b.txt']);
-  } finally {
-    process.chdir(importTimeCwd);
-  }
+test('cwd defaults to process.cwd() evaluated at call time, not import time', async t => {
+  t.mock.method(process, 'cwd', () => cwd); // cwd !== importTimeCwd (fixture is in a temp dir)
+  const files = await glob('a/*.txt'); // no cwd passed - must use call-time process.cwd()
+  assert.deepEqual(files.sort(), ['a/a.txt', 'a/b.txt']);
 });
 
 test('explicit undefined options fall back to defaults', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -305,9 +305,12 @@ test('common path prefix is respected across multiple patterns', async () => {
 });
 
 test('cwd defaults to process.cwd() evaluated at call time, not import time', async t => {
-  t.mock.method(process, 'cwd', () => cwd); // cwd !== importTimeCwd (fixture is in a temp dir)
+  const { mock } = t.mock.method(process, 'cwd', () => cwd); // cwd !== importTimeCwd (fixture is in a temp dir)
+
   const files = await glob('a/*.txt'); // no cwd passed - must use call-time process.cwd()
   assert.deepEqual(files.sort(), ['a/a.txt', 'a/b.txt']);
+
+  mock.restore();
 });
 
 test('explicit undefined options fall back to defaults', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -308,15 +308,15 @@ test('explicit undefined options fall back to defaults', async () => {
   // cwd: undefined should not throw
   await assert.doesNotReject(() => glob('*', { cwd: undefined }));
 
-  // expandDirectories defaults to true — directories should be expanded
+  // expandDirectories defaults to true - directories should be expanded
   const expandFiles = await glob('a', { cwd, expandDirectories: undefined });
   assert.deepEqual(expandFiles.sort(), ['a/a.txt', 'a/b.txt']);
 
-  // onlyFiles defaults to true — directories should not appear
+  // onlyFiles defaults to true - directories should not appear
   const onlyFilesResult = await glob('a', { cwd, onlyFiles: undefined });
   assert.ok(!onlyFilesResult.includes('a/'));
 
-  // caseSensitiveMatch defaults to true — uppercase pattern should not match
+  // caseSensitiveMatch defaults to true - uppercase pattern should not match
   const caseFiles = await glob('**/A.TXT', { cwd, caseSensitiveMatch: undefined });
   assert.deepEqual(caseFiles, []);
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -299,6 +299,28 @@ test('absolute + empty commonPath', async () => {
   assert.deepEqual(files.sort(), [`${escapedCwd}/a/a.txt`, `${escapedCwd}/a/b.txt`]);
 });
 
+test('common path prefix is respected across multiple patterns', async () => {
+  const files = await glob(['a/a.txt', 'a/b.txt'], { cwd });
+  assert.deepEqual(files.sort(), ['a/a.txt', 'a/b.txt']);
+});
+
+test('explicit undefined options fall back to defaults', async () => {
+  // cwd: undefined should not throw
+  await assert.doesNotReject(() => glob('*', { cwd: undefined }));
+
+  // expandDirectories defaults to true — directories should be expanded
+  const expandFiles = await glob('a', { cwd, expandDirectories: undefined });
+  assert.deepEqual(expandFiles.sort(), ['a/a.txt', 'a/b.txt']);
+
+  // onlyFiles defaults to true — directories should not appear
+  const onlyFilesResult = await glob('a', { cwd, onlyFiles: undefined });
+  assert.ok(!onlyFilesResult.includes('a/'));
+
+  // caseSensitiveMatch defaults to true — uppercase pattern should not match
+  const caseFiles = await glob('**/A.TXT', { cwd, caseSensitiveMatch: undefined });
+  assert.deepEqual(caseFiles, []);
+});
+
 test('handle symlinks', async () => {
   const files = await glob('.symlink/**', { cwd });
   assert.deepEqual(files.sort(), ['.symlink/dir/a.txt', '.symlink/dir/b.txt', '.symlink/file']);


### PR DESCRIPTION
### Description

Fixes a regression introduced in #170 where spreading user-supplied glob options over `defaultOptions` allowed explicit `undefined` values to overwrite the truthy defaults.

The old `normalizeCwd` function guarded against the undefined `cwd` explicitly, but the refactor lost that guard.

This PR introduces a fix to `getOptions` which now iterates over the fixed set of `defaultOptions` keys, filling in any user-supplied option that is `undefined`.

Closes https://github.com/SuperchupuDev/tinyglobby/issues/198

---

### Tests

Added tests verifying that the glob options all apply their truthy defaults when passed explicitly as undefined.