### PR TITLE
don't expand directories on a terminal negation extglob

### DIFF
--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -4,6 +4,7 @@ import { ensureNonDriveRelativePath, escapePath, isDynamicPattern, splitPattern 
 
 const PARENT_DIRECTORY = /^(\/?\.\.)+/;
 const ESCAPING_BACKSLASHES = /\\(?=[()[\]{}!*+?@|])/g;
+const TERMINAL_NEGATION_EXTGLOB = /(?:^|\/)!\([^/]*\)$/;
 
 function normalizePattern(pattern: string, opts: InternalOptions, props: InternalProps, isIgnore: boolean) {
   const cwd = opts.cwd as string;
@@ -13,7 +14,8 @@ function normalizePattern(pattern: string, opts: InternalOptions, props: Interna
     result = pattern.slice(0, -1);
   }
   // using a directory as entry should match all files inside it
-  if (result[result.length - 1] !== '*' && opts.expandDirectories) {
+  // don't do it if the pattern ends in a negation extglob though, as that would re-include the excluded files (#188)
+  if (result[result.length - 1] !== '*' && opts.expandDirectories && !TERMINAL_NEGATION_EXTGLOB.test(result)) {
     result += '/**';
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -423,6 +423,30 @@ test('extglob false', async () => {
   assert.deepEqual(files.sort(), []);
 });
 
+test('negation extglob at the end of a pattern is not re-included by directory expansion', async () => {
+  const localFixture = await createFixture({
+    'loc/one/en.po': '',
+    'loc/one/fr.po': '',
+    'loc/two/en.po': '',
+    'loc/two/de.po': ''
+  });
+  const files = await glob(['loc/**/!(en.po)'], { cwd: localFixture.path });
+  assert.deepEqual(files.sort(), ['loc/one/fr.po', 'loc/two/de.po']);
+  await localFixture.rm();
+});
+
+test('negation extglob not at the end of a pattern still works', async () => {
+  const localFixture = await createFixture({
+    'loc/one/en.po': '',
+    'loc/one/fr.po': '',
+    'loc/two/en.po': '',
+    'loc/two/de.po': ''
+  });
+  const files = await glob(['loc/**/!(en).po'], { cwd: localFixture.path });
+  assert.deepEqual(files.sort(), ['loc/one/fr.po', 'loc/two/de.po']);
+  await localFixture.rm();
+});
+
 test('using negated bracket expression', async () => {
   const files = await glob('**/[!a].*', { cwd });
   assert.deepEqual(files.sort(), ['a/b.txt', 'b/b.txt']);


### PR DESCRIPTION
Fixes #188. With the default `expandDirectories: true`, a pattern ending in a negation extglob returns the files it should exclude — `glob(['loc/**/!(en.po)'])` hands back every `en.po`.

The issue is labeled `upstream`, but picomatch is correct: `picomatch('loc/**/!(en.po)')('loc/one/en.po')` is `false`. The bug is in tinyglobby's own `normalizePattern`, which appends `/**` to any pattern not ending in `*` — so `loc/**/!(en.po)` becomes `loc/**/!(en.po)/**`, and now `!(en.po)` matches the *directory* while the trailing `/**` re-adds `en.po` underneath. Running the same glob with `expandDirectories: false` returns the correct result, confirming the append is the cause.

The fix skips the `/**` append when the final segment is a negation extglob. It's deliberately narrow — only a terminal `!(...)` — so `loc/**/!(en).po` and other forms still expand as before.
