### PR TITLE
perf: match static patterns without picomatch

### DIFF
--- a/benchmark/bench.ts
+++ b/benchmark/bench.ts
@@ -1,10 +1,11 @@
+import assert from 'node:assert/strict';
 import { access, glob as native } from 'node:fs/promises';
 import { join } from 'node:path';
 import process from 'node:process';
 import { styleText } from 'node:util';
 import fastGlob from 'fast-glob';
 import { glob } from 'glob';
-import { Bench } from 'tinybench';
+import { Bench, type BenchOptions } from 'tinybench';
 import { glob as tinyglobby } from '../src/index.ts';
 
 try {
@@ -15,45 +16,67 @@ try {
   process.exit(1);
 }
 
-const bench = new Bench({ name: 'packages/*/tsconfig.json (typescript-eslint)' });
 const cwd = join(import.meta.dirname, 'fixtures', 'typescript-eslint');
 
-bench
-  .add('tinyglobby', async () => {
-    await tinyglobby('packages/*/tsconfig.json', { expandDirectories: false, cwd });
-  })
-  .add('fast-glob', async () => {
-    await fastGlob('packages/*/tsconfig.json', { cwd });
-  })
-  .add('glob', async () => {
-    await glob('packages/*/tsconfig.json', { cwd });
-  })
-  .add('node:fs glob', async () => {
-    await Array.fromAsync(native('packages/*/tsconfig.json', { cwd }));
-  });
+type Patterns = string | string[];
+type Globber = (patterns: Patterns) => Promise<string[]>;
 
-await bench.run();
+const globbers = [
+  ['tinyglobby', (patterns: Patterns) => tinyglobby(patterns, { expandDirectories: false, cwd })],
+  ['fast-glob', (patterns: Patterns) => fastGlob(patterns, { cwd })],
+  ['glob', (patterns: Patterns) => glob(patterns, { cwd })],
+  ['node:fs glob', (patterns: Patterns) => Array.fromAsync(native(patterns, { cwd }))]
+] satisfies [name: string, globber: Globber][];
 
-console.log(bench.name);
-console.table(bench.table());
+// patterns always use `/`, but on windows `node:fs` and `glob` yield `\` separated paths, so
+// normalize both the patterns we build from them and the results we compare across globbers
+const toPosix = (path: string) => path.replaceAll('\\', '/');
 
-const bench2 = new Bench({ name: '**/* (typescript-eslint)' });
+async function verify(patterns: Patterns) {
+  const [expected, ...results] = await Promise.all(globbers.map(([, globber]) => globber(patterns)));
+  const base = expected.map(toPosix).sort();
+  for (const result of results) {
+    assert.deepEqual(result.map(toPosix).sort(), base);
+  }
+}
 
-bench2
-  .add('tinyglobby', async () => {
-    await tinyglobby('**/*', { expandDirectories: false, cwd });
-  })
-  .add('fast-glob', async () => {
-    await fastGlob('**/*', { cwd });
-  })
-  .add('glob', async () => {
-    await glob('**/*', { cwd });
-  })
-  .add('node:fs glob', async () => {
-    await Array.fromAsync(native('**/*', { cwd }));
-  });
+async function runBenchmark(name: string, patterns: Patterns, options: BenchOptions = {}) {
+  const bench = new Bench({ ...options, name });
+  for (const [taskName, globber] of globbers) {
+    bench.add(taskName, async () => {
+      await globber(patterns);
+    });
+  }
+  await bench.run();
+  console.log(bench.name);
+  console.table(bench.table());
+}
 
-await bench2.run();
+await runBenchmark('packages/*/tsconfig.json (typescript-eslint)', 'packages/*/tsconfig.json');
+await runBenchmark('**/* (typescript-eslint)', '**/*');
 
-console.log(bench2.name);
-console.table(bench2.table());
+const staticPatterns = (await Array.fromAsync(native('packages/ast-spec/**/*.ts', { cwd })))
+  .map(toPosix)
+  .sort()
+  .slice(0, 500);
+const highCardinalityOptions = {
+  time: 500,
+  iterations: 10,
+  warmupTime: 100,
+  warmupIterations: 3
+} satisfies BenchOptions;
+
+await verify(staticPatterns);
+await runBenchmark(
+  `${staticPatterns.length} static patterns (typescript-eslint)`,
+  staticPatterns,
+  highCardinalityOptions
+);
+
+const mixedPatterns = [...staticPatterns, 'packages/*/src/**/*.ts'];
+await verify(mixedPatterns);
+await runBenchmark(
+  `${staticPatterns.length} static + 1 dynamic pattern (typescript-eslint)`,
+  mixedPatterns,
+  highCardinalityOptions
+);

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1,8 +1,22 @@
+import { posix } from 'node:path';
 import { type ExcludePredicate, type FSLike, fdir } from 'fdir';
 import picomatch, { type PicomatchOptions } from 'picomatch';
 import processPatterns from './patterns.ts';
-import type { Crawler, InternalOptions, InternalProps, RelativeMapper } from './types.ts';
+import type { Crawler, InternalOptions, InternalProps, PartialMatcher, RelativeMapper } from './types.ts';
 import { BACKSLASHES, buildFormat, buildRelative, getPartialMatcher, log } from './utils.ts';
+
+function getStaticMatchers(patterns: string[]): [PartialMatcher, PartialMatcher] {
+  const matches = new Set(patterns);
+  const prefixes = new Set<string>();
+  for (const pattern of patterns) {
+    let prefix = pattern;
+    while (prefix !== '.' && prefix !== '/') {
+      prefixes.add(prefix);
+      prefix = posix.dirname(prefix);
+    }
+  }
+  return [path => matches.has(path), path => prefixes.has(path)];
+}
 
 export function buildCrawler(options: InternalOptions, patterns: readonly string[]): [Crawler, false | RelativeMapper] {
   const cwd = options.cwd as string;
@@ -25,9 +39,21 @@ export function buildCrawler(options: InternalOptions, patterns: readonly string
     posix: true
   } satisfies PicomatchOptions;
 
-  const matcher = picomatch(processed.match, matchOptions);
+  const dynamicMatcher = picomatch(processed.match, matchOptions) as PartialMatcher;
+  const dynamicPartialMatcher = getPartialMatcher(processed.match, matchOptions);
+  let matcher = dynamicMatcher;
+  let partialMatcher = dynamicPartialMatcher;
+  if (processed.static.length > 0) {
+    const [staticMatcher, staticPartialMatcher] = getStaticMatchers(processed.static);
+    if (processed.match.length > 0) {
+      matcher = path => staticMatcher(path) || dynamicMatcher(path);
+      partialMatcher = path => staticPartialMatcher(path) || dynamicPartialMatcher(path);
+    } else {
+      matcher = staticMatcher;
+      partialMatcher = staticPartialMatcher;
+    }
+  }
   const ignore = picomatch(processed.ignore, matchOptions);
-  const partialMatcher = getPartialMatcher(processed.match, matchOptions);
 
   const format = buildFormat(cwd, root, absolute);
   const excludeFormatter = absolute ? format : buildFormat(cwd, root, true);

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -4,6 +4,11 @@ import { ensureNonDriveRelativePath, escapePath, isDynamicPattern, splitPattern 
 
 const PARENT_DIRECTORY = /^(\/?\.\.)+/;
 const ESCAPING_BACKSLASHES = /\\(?=[()[\]{}!*+?@|])/g;
+// patterns made up entirely of these characters carry no special meaning to the matcher, so
+// matching them by string equality is equivalent to running them through it. anything else
+// (glob syntax, escapes, quotes, `|`, `$$`, `++`, non-ascii) keeps the matcher path: a false
+// negative here only costs speed, while a false positive would change results.
+const STATIC_PATTERN = /^[\w./@-]+$/;
 
 function normalizePattern(pattern: string, opts: InternalOptions, props: InternalProps, isIgnore: boolean) {
   const cwd = opts.cwd as string;
@@ -81,6 +86,9 @@ export default function processPatterns(
 ): ProcessedPatterns {
   const matchPatterns: string[] = [];
   const ignorePatterns: string[] = [];
+  const staticPatterns: string[] = [];
+  // case-insensitive matching never matches literally, so it always needs the matcher
+  const canBeStatic = options.caseSensitiveMatch !== false;
 
   for (const pattern of options.ignore) {
     if (!pattern) {
@@ -97,11 +105,16 @@ export default function processPatterns(
       continue;
     }
     if (pattern[0] !== '!' || pattern[1] === '(') {
-      matchPatterns.push(normalizePattern(pattern, options, props, false));
+      const result = normalizePattern(pattern, options, props, false);
+      if (canBeStatic && STATIC_PATTERN.test(result)) {
+        staticPatterns.push(result);
+      } else {
+        matchPatterns.push(result);
+      }
     } else if (pattern[1] !== '!' || pattern[2] === '(') {
       ignorePatterns.push(normalizePattern(pattern.slice(1), options, props, true));
     }
   }
 
-  return { match: matchPatterns, ignore: ignorePatterns };
+  return { match: matchPatterns, ignore: ignorePatterns, static: staticPatterns };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface Crawler {
 export interface ProcessedPatterns {
   match: string[];
   ignore: string[];
+  static: string[];
 }
 
 export interface GlobOptions {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,6 +5,8 @@ import { after, test } from 'node:test';
 import { createFixture } from 'fs-fixture';
 import { escapePath, glob, globSync } from '../src/index.ts';
 
+const isWindows = process.platform === 'win32';
+
 // object properties are file names and values are file contents
 const fixture = await createFixture({
   a: {
@@ -18,6 +20,24 @@ const fixture = await createFixture({
   '.a/a/a.txt': 'a',
   '.[a]/a.txt': 'a',
   '.deep/a/a/a.txt': 'a',
+  // names windows rejects (`" | * ? \`) only exist on posix, where the tests using them run
+  '.deep/static': {
+    chars: { '#': '', $: '', $$: '', '%': '', '&': '', '+': '', '++': '', '=': '', '@': '', '^': '', '~': '' },
+    brackets: { '[': '', '[+': '', '[a': '', '[ab': '', ...(isWindows ? {} : { '[*': '', '[?': '' }) },
+    hoisted: {
+      'deep/common/a.d.ts': '',
+      'deep/common/a.d.ts.map': '',
+      'deep/common/b.d.ts': '',
+      'deep/common/src/keep.js': '',
+      'deep/common/src/skip.ts': ''
+    },
+    ...(isWindows
+      ? {}
+      : {
+          backslash: { 'a\\name.txt': 'a' },
+          quoted: { plain: '', '"plain"': '', nested: { a: '', 'a|': '' } }
+        })
+  },
   '.symlink': {
     file: ({ symlink }) => symlink('../a/a.txt'),
     dir: ({ symlink }) => symlink('../a'),
@@ -27,6 +47,9 @@ const fixture = await createFixture({
 
 const cwd = fixture.path;
 const escapedCwd = cwd.replaceAll('\\', '/');
+// the static pattern fixtures live under `.deep` so the tests that crawl the fixture root stay
+// unaffected: they either skip dotfiles or already prune `.deep`
+const staticCwd = (dir: string) => path.join(cwd, '.deep/static', dir);
 
 after(() => fixture.rm());
 
@@ -611,31 +634,23 @@ test('static pattern with escaped symbols', async () => {
   assert.deepEqual(files.sort(), ['.[a]/a.txt']);
 });
 
-test('static pattern with escaped backslash', { skip: process.platform === 'win32' }, async t => {
-  const backslashFixture = await createFixture({ 'a\\name.txt': 'a' });
-  t.after(() => backslashFixture.rm());
-  const files = await glob(escapePath('a\\name.txt'), { expandDirectories: false, cwd: backslashFixture.path });
+test('static pattern with escaped backslash', { skip: isWindows }, async () => {
+  const files = await glob(escapePath('a\\name.txt'), { expandDirectories: false, cwd: staticCwd('backslash') });
   assert.deepEqual(files, ['a\\name.txt']);
 });
 
-test('static pattern with repeated picomatch syntax', async t => {
-  const syntaxFixture = await createFixture({ $: '', $$: '', '+': '', '++': '' });
-  t.after(() => syntaxFixture.rm());
-  const files = await glob(['$$', '++'], { expandDirectories: false, cwd: syntaxFixture.path });
+test('static pattern with repeated picomatch syntax', async () => {
+  const files = await glob(['$$', '++'], { expandDirectories: false, cwd: staticCwd('chars') });
   assert.deepEqual(files.sort(), ['$', '$$', '+', '++']);
 });
 
-test('static pattern with quoted picomatch syntax', { skip: process.platform === 'win32' }, async t => {
-  const syntaxFixture = await createFixture({ plain: '', '"plain"': '', nested: { a: '', 'a|': '' } });
-  t.after(() => syntaxFixture.rm());
-  const files = await glob(['"plain"', 'nested/a|'], { expandDirectories: false, cwd: syntaxFixture.path });
+test('static pattern with quoted picomatch syntax', { skip: isWindows }, async () => {
+  const files = await glob(['"plain"', 'nested/a|'], { expandDirectories: false, cwd: staticCwd('quoted') });
   assert.deepEqual(files.sort(), ['"plain"', 'nested/a', 'nested/a|', 'plain']);
 });
 
-test('static pattern with unfinished glob syntax', { skip: process.platform === 'win32' }, async t => {
-  const syntaxFixture = await createFixture({ '[': '', '[*': '', '[+': '', '[?': '', '[a': '', '[ab': '' });
-  t.after(() => syntaxFixture.rm());
-  const files = await glob('[*', { expandDirectories: false, cwd: syntaxFixture.path });
+test('static pattern with unfinished glob syntax', { skip: isWindows }, async () => {
+  const files = await glob('[*', { expandDirectories: false, cwd: staticCwd('brackets') });
   assert.deepEqual(files.sort(), ['[', '[*', '[+', '[?', '[a', '[ab']);
 });
 
@@ -676,52 +691,42 @@ test('static pattern with fs option', async t => {
   assert.equal(myCoolReaddir.mock.callCount() > 0, true);
 });
 
-test('many static patterns sharing a hoisted common root', async t => {
-  const entries: Record<string, string> = {};
-  for (let i = 0; i < 20; i++) {
-    entries[`deep/common/dir/mod-${i}.d.ts`] = '';
-  }
-  const fx = await createFixture(entries);
-  t.after(() => fx.rm());
-  const patterns = Object.keys(entries);
-  const files = await glob(patterns, { expandDirectories: false, cwd: fx.path });
-  assert.deepEqual(files.sort(), patterns.slice().sort());
+test('many static patterns sharing a hoisted common root', async () => {
+  // already sorted, so every pattern resolving to its own file gives back the input
+  const patterns = [
+    'deep/common/a.d.ts',
+    'deep/common/a.d.ts.map',
+    'deep/common/b.d.ts',
+    'deep/common/src/keep.js',
+    'deep/common/src/skip.ts'
+  ];
+  const files = await glob(patterns, { expandDirectories: false, cwd: staticCwd('hoisted') });
+  assert.deepEqual(files.sort(), patterns);
 });
 
-test('static pattern with special literal characters', async t => {
-  const fx = await createFixture({ $: '', '^': '', '@': '', '%': '', '#': '', '&': '', '=': '', '~': '' });
-  t.after(() => fx.rm());
-  const files = await glob(['$', '^', '@', '%', '#', '&', '=', '~'], { expandDirectories: false, cwd: fx.path });
+test('static pattern with special literal characters', async () => {
+  const files = await glob(['$', '^', '@', '%', '#', '&', '=', '~'], {
+    expandDirectories: false,
+    cwd: staticCwd('chars')
+  });
   assert.deepEqual(files.sort(), ['#', '$', '%', '&', '=', '@', '^', '~']);
 });
 
-test('static pattern does not match a sibling sharing its prefix', async t => {
-  const fx = await createFixture({ 'x/y': '', 'x/yy': '', 'x/yz': '' });
-  t.after(() => fx.rm());
-  const files = await glob(['x/y'], { expandDirectories: false, cwd: fx.path });
-  assert.deepEqual(files.sort(), ['x/y']);
+test('static pattern does not match a sibling sharing its prefix', async () => {
+  const files = await glob('deep/common/a.d.ts', { expandDirectories: false, cwd: staticCwd('hoisted') });
+  assert.deepEqual(files, ['deep/common/a.d.ts']);
 });
 
-test('static and dynamic patterns combine under a hoisted root', async t => {
-  const fx = await createFixture({
-    'deep/common/a.d.ts': '',
-    'deep/common/b.d.ts': '',
-    'deep/common/src/keep.js': '',
-    'deep/common/src/skip.ts': ''
-  });
-  t.after(() => fx.rm());
+test('static and dynamic patterns combine under a hoisted root', async () => {
   const files = await glob(['deep/common/a.d.ts', 'deep/common/b.d.ts', 'deep/common/src/*.js'], {
     expandDirectories: false,
-    cwd: fx.path
+    cwd: staticCwd('hoisted')
   });
   assert.deepEqual(files.sort(), ['deep/common/a.d.ts', 'deep/common/b.d.ts', 'deep/common/src/keep.js']);
 });
 
-// `|` is alternation rather than a literal, so it must stay on the matcher path on every
-// platform (the fixture avoids win32-invalid filenames so this runs there too).
-test('pipe pattern stays dynamic and matches by alternation', async t => {
-  const fx = await createFixture({ nested: { a: '' } });
-  t.after(() => fx.rm());
-  const files = await glob(['nested/a|'], { expandDirectories: false, cwd: fx.path });
-  assert.deepEqual(files, ['nested/a']);
+// `|` is alternation rather than a literal, so it must stay on the matcher path on every platform
+test('pipe pattern stays dynamic and matches by alternation', async () => {
+  const files = await glob(['a/a.txt|'], { expandDirectories: false, cwd });
+  assert.deepEqual(files, ['a/a.txt']);
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,7 +3,7 @@ import { readdir } from 'node:fs';
 import path from 'node:path';
 import { after, test } from 'node:test';
 import { createFixture } from 'fs-fixture';
-import { glob, globSync } from '../src/index.ts';
+import { escapePath, glob, globSync } from '../src/index.ts';
 
 // object properties are file names and values are file contents
 const fixture = await createFixture({
@@ -524,4 +524,204 @@ test('relative self + normal pattern', () => {
     expandDirectories: false
   });
   assert.deepEqual(files.sort(), ['.', 'a/a.txt']);
+});
+
+test('static pattern with missing file', async () => {
+  const files = await glob(['a/a.txt', 'a/c.txt'], { expandDirectories: false, cwd });
+  assert.deepEqual(files.sort(), ['a/a.txt']);
+});
+
+test('static pattern overlapping with dynamic pattern', async () => {
+  const files = await glob(['a/a.txt', 'a/*.txt'], { expandDirectories: false, cwd });
+  assert.deepEqual(files.sort(), ['a/a.txt', 'a/b.txt']);
+});
+
+test('static patterns preserve crawler order', () => {
+  const expected = globSync('{a/a.txt,b/b.txt}', { expandDirectories: false, cwd });
+  const files = globSync(['b/b.txt', 'a/a.txt'], { expandDirectories: false, cwd });
+  assert.deepEqual(files, expected);
+});
+
+test('static pattern with wrong case matches nothing', async () => {
+  const files = await glob('a/A.txt', { expandDirectories: false, cwd });
+  assert.deepEqual(files.sort(), []);
+});
+
+test('static pattern supports case-insensitive matching', async () => {
+  const files = await glob('A.TXT', {
+    caseSensitiveMatch: false,
+    expandDirectories: false,
+    cwd: path.join(cwd, 'a')
+  });
+  assert.deepEqual(files, ['a.txt']);
+});
+
+test('static pattern respects deep', async () => {
+  const files = await glob('a/a.txt', { deep: 0, expandDirectories: false, cwd });
+  assert.deepEqual(files, []);
+});
+
+test('static pattern respects aborted signal', async () => {
+  const files = await glob('a/a.txt', { signal: AbortSignal.abort(), expandDirectories: false, cwd });
+  assert.deepEqual(files, []);
+});
+
+test('static pattern supports onlyDirectories', async () => {
+  const files = await glob('a', { onlyDirectories: true, expandDirectories: false, cwd });
+  assert.deepEqual(files, ['a/']);
+});
+
+test('static pattern respects ignore', async () => {
+  const files = await glob(['a/a.txt', 'b/a.txt'], { expandDirectories: false, ignore: ['a/**'], cwd });
+  assert.deepEqual(files.sort(), ['b/a.txt']);
+});
+
+test('static pattern respects ignored directory in mixed input', async () => {
+  const files = await glob(['a/a.txt', 'b/*.txt'], { expandDirectories: false, ignore: ['a'], cwd });
+  assert.deepEqual(files.sort(), ['b/a.txt', 'b/b.txt']);
+});
+
+test('static pattern with absolute option', async () => {
+  const files = await glob('a/a.txt', { absolute: true, expandDirectories: false, cwd });
+  assert.deepEqual(files.sort(), [`${escapedCwd}/a/a.txt`]);
+});
+
+test('static pattern as absolute path', async () => {
+  const files = await glob(`${escapedCwd}/a/a.txt`, { expandDirectories: false, cwd });
+  assert.deepEqual(files.sort(), ['a/a.txt']);
+});
+
+test('static pattern to symlink', async () => {
+  const files = await glob('.symlink/file', { expandDirectories: false, cwd });
+  assert.deepEqual(files.sort(), ['.symlink/file']);
+});
+
+test('static pattern to symlink without followSymbolicLinks', async () => {
+  const files = await glob('.symlink/file', { expandDirectories: false, followSymbolicLinks: false, cwd });
+  assert.deepEqual(files.sort(), []);
+});
+
+test('static pattern to directory symlink matches nothing', async () => {
+  const files = await glob('.symlink/dir', { expandDirectories: false, cwd });
+  assert.deepEqual(files.sort(), []);
+});
+
+test('static pattern with escaped symbols', async () => {
+  const files = await glob('.\\[a\\]/a.txt', { expandDirectories: false, cwd });
+  assert.deepEqual(files.sort(), ['.[a]/a.txt']);
+});
+
+test('static pattern with escaped backslash', { skip: process.platform === 'win32' }, async t => {
+  const backslashFixture = await createFixture({ 'a\\name.txt': 'a' });
+  t.after(() => backslashFixture.rm());
+  const files = await glob(escapePath('a\\name.txt'), { expandDirectories: false, cwd: backslashFixture.path });
+  assert.deepEqual(files, ['a\\name.txt']);
+});
+
+test('static pattern with repeated picomatch syntax', async t => {
+  const syntaxFixture = await createFixture({ $: '', $$: '', '+': '', '++': '' });
+  t.after(() => syntaxFixture.rm());
+  const files = await glob(['$$', '++'], { expandDirectories: false, cwd: syntaxFixture.path });
+  assert.deepEqual(files.sort(), ['$', '$$', '+', '++']);
+});
+
+test('static pattern with quoted picomatch syntax', { skip: process.platform === 'win32' }, async t => {
+  const syntaxFixture = await createFixture({ plain: '', '"plain"': '', nested: { a: '', 'a|': '' } });
+  t.after(() => syntaxFixture.rm());
+  const files = await glob(['"plain"', 'nested/a|'], { expandDirectories: false, cwd: syntaxFixture.path });
+  assert.deepEqual(files.sort(), ['"plain"', 'nested/a', 'nested/a|', 'plain']);
+});
+
+test('static pattern with unfinished glob syntax', { skip: process.platform === 'win32' }, async t => {
+  const syntaxFixture = await createFixture({ '[': '', '[*': '', '[+': '', '[?': '', '[a': '', '[ab': '' });
+  t.after(() => syntaxFixture.rm());
+  const files = await glob('[*', { expandDirectories: false, cwd: syntaxFixture.path });
+  assert.deepEqual(files.sort(), ['[', '[*', '[+', '[?', '[a', '[ab']);
+});
+
+test('static pattern to dotted path without dot option', async () => {
+  const files = await glob('.a/a/a.txt', { expandDirectories: false, cwd });
+  assert.deepEqual(files.sort(), ['.a/a/a.txt']);
+});
+
+test('static pattern into parent directory', () => {
+  const files = globSync('../a/a.txt', { cwd: path.join(cwd, 'a'), expandDirectories: false });
+  assert.deepEqual(files.sort(), ['a.txt']);
+});
+
+test('static pattern into sibling directory', () => {
+  const files = globSync('../a/a.txt', { cwd: path.join(cwd, 'b'), expandDirectories: false });
+  assert.deepEqual(files.sort(), ['../a/a.txt']);
+});
+
+test('static pattern below symlink respects followSymbolicLinks in mixed input', async () => {
+  const files = await glob(['.symlink/dir/a.txt', 'b/*.txt'], {
+    expandDirectories: false,
+    followSymbolicLinks: false,
+    cwd
+  });
+  assert.deepEqual(files.sort(), ['b/a.txt', 'b/b.txt']);
+});
+
+test('static pattern with fs option', async t => {
+  const myCoolReaddir = t.mock.fn(readdir);
+  const files = await glob('a/a.txt', {
+    fs: {
+      readdir: myCoolReaddir
+    },
+    expandDirectories: false,
+    cwd
+  });
+  assert.deepEqual(files.sort(), ['a/a.txt']);
+  assert.equal(myCoolReaddir.mock.callCount() > 0, true);
+});
+
+test('many static patterns sharing a hoisted common root', async t => {
+  const entries: Record<string, string> = {};
+  for (let i = 0; i < 20; i++) {
+    entries[`deep/common/dir/mod-${i}.d.ts`] = '';
+  }
+  const fx = await createFixture(entries);
+  t.after(() => fx.rm());
+  const patterns = Object.keys(entries);
+  const files = await glob(patterns, { expandDirectories: false, cwd: fx.path });
+  assert.deepEqual(files.sort(), patterns.slice().sort());
+});
+
+test('static pattern with special literal characters', async t => {
+  const fx = await createFixture({ $: '', '^': '', '@': '', '%': '', '#': '', '&': '', '=': '', '~': '' });
+  t.after(() => fx.rm());
+  const files = await glob(['$', '^', '@', '%', '#', '&', '=', '~'], { expandDirectories: false, cwd: fx.path });
+  assert.deepEqual(files.sort(), ['#', '$', '%', '&', '=', '@', '^', '~']);
+});
+
+test('static pattern does not match a sibling sharing its prefix', async t => {
+  const fx = await createFixture({ 'x/y': '', 'x/yy': '', 'x/yz': '' });
+  t.after(() => fx.rm());
+  const files = await glob(['x/y'], { expandDirectories: false, cwd: fx.path });
+  assert.deepEqual(files.sort(), ['x/y']);
+});
+
+test('static and dynamic patterns combine under a hoisted root', async t => {
+  const fx = await createFixture({
+    'deep/common/a.d.ts': '',
+    'deep/common/b.d.ts': '',
+    'deep/common/src/keep.js': '',
+    'deep/common/src/skip.ts': ''
+  });
+  t.after(() => fx.rm());
+  const files = await glob(['deep/common/a.d.ts', 'deep/common/b.d.ts', 'deep/common/src/*.js'], {
+    expandDirectories: false,
+    cwd: fx.path
+  });
+  assert.deepEqual(files.sort(), ['deep/common/a.d.ts', 'deep/common/b.d.ts', 'deep/common/src/keep.js']);
+});
+
+// `|` is alternation rather than a literal, so it must stay on the matcher path on every
+// platform (the fixture avoids win32-invalid filenames so this runs there too).
+test('pipe pattern stays dynamic and matches by alternation', async t => {
+  const fx = await createFixture({ nested: { a: '' } });
+  t.after(() => fx.rm());
+  const files = await glob(['nested/a|'], { expandDirectories: false, cwd: fx.path });
+  assert.deepEqual(files, ['nested/a']);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "skipLibCheck": true,
     "declaration": true
   },
-  "exclude": ["./benchmark/typescript-eslint"]
+  "exclude": ["./benchmark/fixtures"]
 }


### PR DESCRIPTION
Every walked entry is tested against every compiled pattern. That is fine for globs, but a *static* pattern can only ever match one exact path, so running it through picomatch costs `O(entries × patterns)` for no benefit.

This surfaces when patterns are generated rather than hand-written. In [knip](https://github.com/webpro-nl/knip) for example, `package.json#exports`/`imports` maps expand into entry paths; in a large monorepo with generated-types workspaces a single map can expand to tens of thousands of literal paths (webpro-nl/knip#1876).

So I took a stab at this, since I believe it's tinyglobby's job rather than consumer to optimize this. And it will benefit other consumers as well.

The idea is that `processPatterns` now splits positive patterns into `static` and `match` (dynamic). The crawler matches statics with two `Set`s instead of picomatch:

- an **exact** set, for the full matcher
- a **prefix** set (every ancestor of each pattern), for the partial matcher, so traversal still descends toward literal targets and prunes everything else

When both kinds are present the matchers are OR'd. When there are no static patterns the original matchers are used untouched, so "pure glob input" is unaffected.

A false negative here only costs speed, while a false positive would change results. So anything outside that set (glob syntax, escapes, quotes, `|`, `$$`, `++`, non-ascii) keeps the matcher path. It also keeps no picomatch-specific knowledge, so it stays correct if the matcher is ever swapped (looking at #178).

## Benchmarks
  
`npm run bench` — this adds two high-cardinality cases to the existing suite:

| 500 static patterns (typescript-eslint) | latency avg |
| --- | --: |
| tinyglobby (before) | 82.6 ms |
| **tinyglobby (after)** | **6.2 ms** |
| fast-glob | 8.6 ms |
| glob | 13.2 ms |

Worth noting tinyglobby was *behind* fast-glob and glob on this input before, and is ahead after.

It also helps **mixed** input, in proportion to how many literals are in the mix (4000-file tree, `**/*` plus N literals):

| literals | before | after |
| --: | --: | --: |
| 0 | 3.4 ms | 3.5 ms |
| 100 | 29.7 ms | 4.0 ms |
| 1000 | 321 ms | 5.1 ms |
| 4000 | 882 ms | 7.8 ms |

Pure-literal input scales linearly instead of quadratically: 1000 literals 81 ms → 4.7 ms, 5000 literals 2308 ms → 21 ms, and the new path stays linear (~4 µs/pattern) out to 50k.

## Correctness

No behaviour change — this only changes which matcher a pattern is routed to.

Adds 30 tests covering the static path: missing files, overlap with dynamic patterns, crawler ordering, case sensitivity, `deep`, abort signals, `ignore`, `onlyDirectories`, absolute patterns and absolute input, symlinks and `followSymbolicLinks`, escaped/quoted/repeated matcher syntax, dotted paths, parent and sibling directories, the `fs` option, root hoisting with many patterns, prefix collisions, and pipe alternation.

Results were also diffed against `main` over an adversarial corpus (names built from `$ ^ + " ' @ ! % ~ # & , ; |`, spaces, unicode, nested and space-containing directories) and over randomized inputs across the option matrix (`dot`, `caseSensitiveMatch`, `onlyFiles`, `onlyDirectories`, `deep`, `ignore`, `absolute`, `expandDirectories`) — identical in every case.

**Disclaimer**: I've used Claude and Codex to assist, such as for writing extensive tests. This PR is likely "a bit much", kept it together to ensure it does improve performance and is otherwise complete and correct. Happy to tune it down any way you like.