### PR TITLE
fix(partial-matcher): let `**` match zero path segments

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,7 +20,8 @@ export function getPartialMatcher(patterns: string[], options: PartialMatcherOpt
   const patternsCount = patterns.length;
   const patternsParts: string[][] = Array(patternsCount);
   const matchers: Matcher[][] = Array(patternsCount);
-  let i: number, j: number;
+  const globstar = !options.noglobstar;
+  let i: number, j: number, k: number;
 
   for (i = 0; i < patternsCount; i++) {
     const parts = splitPattern(patterns[i]);
@@ -45,14 +46,18 @@ export function getPartialMatcher(patterns: string[], options: PartialMatcherOpt
       return true;
     }
 
+    const inputPartsCount = inputParts.length;
+
     for (i = 0; i < patternsCount; i++) {
       const patternParts = patternsParts[i];
       const matcher = matchers[i];
-      const inputPatternCount = inputParts.length;
-      const minParts = Math.min(inputPatternCount, patternParts.length);
+      const patternPartsCount = patternParts.length;
 
+      // `j` walks the pattern, `k` walks the input. They only go out of sync when a
+      // `**` matches zero path segments, which is the one case where the two differ.
       j = 0;
-      while (j < minParts) {
+      k = 0;
+      while (j < patternPartsCount && k < inputPartsCount) {
         const part = patternParts[j];
 
         // handling slashes in parts is very hard, not even fast-glob does it
@@ -62,20 +67,29 @@ export function getPartialMatcher(patterns: string[], options: PartialMatcherOpt
           return true;
         }
 
-        if (!matcher[j](inputParts[j])) {
+        if (globstar && part === '**') {
+          // unlike popular belief, `**` doesn't return true in *all* cases
+          // some examples are when matching it to `.a` with dot: false or `..`
+          // so it needs to match to consume one or more segments and return early
+          if (matcher[j](inputParts[k])) {
+            return true;
+          }
+
+          // `**` also matches zero segments, so the rest of the pattern still has to
+          // be tried against the same input part. Without this, a pattern like
+          // `**/.a/*.ts` would never crawl into `.a` when `dot` is false.
+          j++;
+          continue;
+        }
+
+        if (!matcher[j](inputParts[k])) {
           break;
         }
 
-        // unlike popular belief, `**` doesn't return true in *all* cases
-        // some examples are when matching it to `.a` with dot: false or `..`
-        // so it needs to match to return early
-        if (!options.noglobstar && part === '**') {
-          return true;
-        }
-
         j++;
+        k++;
       }
-      if (j === inputPatternCount) {
+      if (k === inputPartsCount) {
         return true;
       }
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -207,6 +207,18 @@ test('leading ../', async () => {
   assert.deepEqual(files.sort(), ['../b/a.txt', '../b/b.txt']);
 });
 
+// `**` also matches zero path segments, so `**/.a/**` has to reach `.a` at the
+// root even though `dot` is false and `**` on its own doesn't match `.a`.
+test('leading ** before a dot directory', async () => {
+  const files = await glob('**/.a/a/*.txt', { cwd, expandDirectories: false });
+  assert.deepEqual(files.sort(), ['.a/a/a.txt']);
+});
+
+test('** before a dot directory with a trailing **', async () => {
+  const files = await glob('**/.deep/a/**/*.txt', { cwd, expandDirectories: false });
+  assert.deepEqual(files.sort(), ['.deep/a/a/a.txt']);
+});
+
 test('leading ../ with only dirs', async () => {
   const files = await glob('../.a/*', { cwd: path.join(cwd, 'a'), onlyDirectories: true, expandDirectories: false });
   assert.deepEqual(files.sort(), ['../.a/a/']);

--- a/test/utils/partial-matcher.test.ts
+++ b/test/utils/partial-matcher.test.ts
@@ -140,4 +140,31 @@ describe('getPartialMatcher', () => {
     assert.ok(matcher('src/utils'));
     assert.ok(!matcher('src/gaming'));
   });
+
+  test('leading ** matches zero segments', () => {
+    // `**` matching nothing is what makes `**/.a` match `.a` at the root.
+    // With `dot: false` the `**` matcher itself rejects `.a`, so the rest of
+    // the pattern has to be tried against the same input part.
+    const matcher = getPartialMatcher(['**/.a/*.txt']);
+    assert.ok(matcher('.a'));
+    assert.ok(matcher('.a/b.txt'));
+    assert.ok(matcher('src/.a'));
+    assert.ok(!matcher('.b'));
+  });
+
+  test('** matches zero segments in the middle of a pattern', () => {
+    const matcher = getPartialMatcher(['test/**/.a/*.txt']);
+    assert.ok(matcher('test'));
+    assert.ok(matcher('test/.a'));
+    assert.ok(matcher('test/utils/.a'));
+    assert.ok(!matcher('test/.b'));
+  });
+
+  test('** matching zero segments does not create false positives', () => {
+    const matcher = getPartialMatcher(['a/**/.b/c']);
+    assert.ok(matcher('a'));
+    assert.ok(matcher('a/.b'));
+    assert.ok(!matcher('.b'));
+    assert.ok(!matcher('a/.c'));
+  });
 });


### PR DESCRIPTION
Fixes #187.

### The bug

`getPartialMatcher` is the predicate that decides whether a directory is worth descending into. It walked the pattern parts and the input parts in lockstep with a single index, which meant `**` could only ever stand for **one or more** segments — as soon as the `**` matcher rejected the current input part, the whole pattern was abandoned.

`**` also matches **zero** segments, and that case matters as soon as the segment right after the `**` is the one that matches. With `dot: false`, picomatch's `**` does not match `.foo`, so:

```js
await glob('**/.foo/*.ts', { cwd, expandDirectories: false });
// tinyglobby: []
// fast-glob:  ['.foo/foo.ts']
```

The crawler never entered `.foo`, so the correct full matcher downstream never got the chance to run. With `dot: true` the `**` matcher accepts `.foo`, which is why the issue only reproduces on the default.

The same shape breaks any pattern where a `**` precedes a segment the `**` itself won't match — `**/.deep/a/**/*.txt` returned `[]` too.

### The fix

Track the pattern position (`j`) and the input position (`k`) separately. When a `**` doesn't consume the current input segment, advance only the pattern and retry the next pattern part against the same segment, instead of ending the walk. When it does consume it, the existing early `return true` is unchanged.

The two indices only diverge in that one case, so the common path costs the same. `noglobstar` still treats `**` as a literal part.

### Validation

- `pnpm test` → **135 pass, 0 fail**. Reverting only `src/utils.ts` fails all 5 new assertions, so they pin the fix rather than restate current behavior.
- `pnpm typecheck`, `pnpm check` (biome), `pnpm build` all clean.
- `pnpm bench` on the `typescript-eslint` fixture — no regression, tinyglobby still fastest in both:

  | | tinyglobby | fast-glob | glob |
  |---|---|---|---|
  | `packages/*/tsconfig.json` | **2627 ops/s** | 2598 | 2249 |
  | `**/*` | **50 ops/s** | 35 | 19 |

Tests added: three unit tests on `getPartialMatcher` (leading `**`, mid-pattern `**`, and a negative case that the looser walk doesn't turn into a false positive) plus two integration tests against the existing `.a` / `.deep` fixtures.

I did not touch the `dot` semantics themselves — this is purely the traversal predicate being stricter than the matcher it guards. The other half of #187 (whether `dot: false` should skip dot *directories* at all, as opposed to dot *files*) is a deliberate behavior choice and is left alone.

---
🤖 Written with assistance from Claude Code.
